### PR TITLE
Enable Travis CI and Sauce Labs integration.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,24 @@
+sudo: required
+
+language: c
+
+services:
+  - docker
+
+before_script:
+- curl -sL https://deb.nodesource.com/setup_4.x | sudo -E bash -
+- sudo apt-get install -y nodejs
+- docker pull jupyter/pyspark-notebook:3.2
+- docker pull cloudet/pyspark-notebook-bower-sparkkernel
+
+script:
+- make test-js-remote
+- make test-py
+- make test-scala
+- make sdist
+- make install
+
+notifications:
+  email:
+    on_success: change
+    on_failure: always

--- a/Makefile
+++ b/Makefile
@@ -143,6 +143,10 @@ test-js: | $(URTH_COMP_LINKS)
 	@echo 'Running web component tests...'
 	@npm run test
 
+test-js-remote: | $(URTH_COMP_LINKS)
+	@echo 'Running web component tests remotely on Sauce Labs...'
+	@npm run test-sauce --silent -- --sauce-username $(SAUCE_USER_NAME) --sauce-access-key $(SAUCE_ACCESS_KEY)
+
 test-py: REPO?=jupyter/pyspark-notebook:3.2
 test-py: dist/urth
 	@echo 'Running python tests...'

--- a/elements/urth-core-import/test/urth-core-import.html
+++ b/elements/urth-core-import/test/urth-core-import.html
@@ -53,7 +53,6 @@
 
         // STEP 5: Define suite(s) and tests.
         describe('package attribute', function() {
-            this.timeout(500);
             it('should cause POST server request to install the package if href is not found', function(done) {
                 server.respondWith('POST', '/urth_import',
                     [200, { 'Content-Type': 'application/json' }, '{ "status": 0}']);
@@ -82,7 +81,6 @@
         });
 
         describe('importerror', function() {
-            this.timeout(500);
             it('should fire if the server is not responding', function(done) {
                 var link = fixture('invalidHref');
 

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
   "scripts": {
     "bower": "bower",
     "test": "wct elements/*/test",
+    "test-sauce": "wct --skip-plugin local --plugin sauce elements/*/test",
     "watch": "gulp watch"
   },
   "repository": {

--- a/wct.conf.js
+++ b/wct.conf.js
@@ -6,6 +6,26 @@ module.exports = {
   plugins: {
     local: {
       browsers: ['chrome']
+    },
+    sauce: {
+      disabled: true,
+      browsers: [
+          {
+              browserName: "chrome",
+              platform: "Linux",
+              version: "45.0"
+          },
+          {
+              browserName: "chrome",
+              platform: "OS X 10.10",
+              version: "45.0"
+          },
+          {
+              browserName: "chrome",
+              platform: "Windows 10",
+              version: "45.0"
+          }
+      ]
     }
   },
   webserver: {


### PR DESCRIPTION
This commit contains the changes required to enable Travis CI builds of the project and execution of the front end unit tests through Sauce Labs. Prior to merging this commit the following steps should be performed:
1. Create an account on [Sauce Labs](https://saucelabs.com/signup) and specify this repo for the repository URL.
2. On the account page (left hand side) copy the Access Key.

![screen shot 2015-09-30 at 3 42 32 pm](https://cloud.githubusercontent.com/assets/782384/10206008/43b2fa72-678a-11e5-87c8-76f8303358ef.png)
3. Sign in to [Travis CI](https://travis-ci.org/auth) using a github account that has admin access to this repo.
4. On the [profile page](https://travis-ci.org/profile) enable Travis CI builds for this repo.
![screen shot 2015-09-30 at 3 40 24 pm](https://cloud.githubusercontent.com/assets/782384/10205907/a18c69ae-6789-11e5-9d3e-a90953980946.png)
5. Click the gear next to the switch for the repo to access the repository settings page.
6. Define two new environment variables:
- SAUCE_USER_NAME - User name you used to log in to Sauce Labs.
- SAUCE_ACCESS_KEY - Access Key copied in step 2.

![screen shot 2015-09-30 at 3 41 40 pm](https://cloud.githubusercontent.com/assets/782384/10205931/c61b22b0-6789-11e5-8251-8c204d88d08a.png)
7. (Optional) On the repository settings page, click the build status badge to open a dialog and select 'Markdown' in the dialog to get the syntax to include in README.md to show build status. 
![screen shot 2015-09-30 at 3 36 37 pm](https://cloud.githubusercontent.com/assets/782384/10205885/7ae409b0-6789-11e5-99c1-639cec861c23.png)
Add a commit to README.md with the copied line inserted at the top of the file.

With the above steps performed, the merge of this commit should then initiate a build in Travis CI.
