### PR TITLE
Fixes for #7 and #17. Suppress extra onModelChange calls an comm messages from kernel

### DIFF
--- a/elements/urth-core-behaviors/jupyter-widget-behavior.html
+++ b/elements/urth-core-behaviors/jupyter-widget-behavior.html
@@ -114,7 +114,7 @@ This behavior is used to encapsulate some of the services needed for ipywidgets.
                     console.debug('Urth.JupyterWidgetBehavior sync - sending values', values);
                     var valKeys = Object.keys(values || {});
                     valKeys.forEach(function (value) {
-                        this.model.set(value, values[value]);
+                        this.model.set(value, values[value], {silent: true});
                     }.bind(this));
 
                     if (valKeys.length > 0)

--- a/kernel-python/urth/widgets/tests/test_urth_widget.py
+++ b/kernel-python/urth/widgets/tests/test_urth_widget.py
@@ -1,0 +1,21 @@
+# (c) Copyright Jupyter Development Team
+# (c) Copyright IBM Corp. 2015
+
+""" Tests for the urth_widget.py module """
+
+import unittest
+from IPython.kernel.comm import Comm
+from unittest.mock import Mock
+
+from ..urth_widget import *
+
+
+class TestUrthWidget(unittest.TestCase):
+
+    def test_no_state_msg_on_create(self):
+        """should not send a state message when the widget is created"""
+        comm = Mock(spec=Comm)
+        send = Mock()
+        comm.attach_mock(send, 'send')
+        widget = UrthWidget(comm=comm)
+        assert(send.call_count == 0)

--- a/kernel-python/urth/widgets/urth_widget.py
+++ b/kernel-python/urth/widgets/urth_widget.py
@@ -1,0 +1,17 @@
+# Copyright (c) Jupyter Development Team.
+# Distributed under the terms of the Modified BSD License.
+
+from IPython.html import widgets  # Widget definitions
+
+
+class UrthWidget(widgets.Widget):
+    """ A base class for Urth widgets. """
+
+    def __init__(self, **kwargs):
+        super(UrthWidget, self).__init__(**kwargs)
+
+    def send_state(self, key=None):
+        """Overrides the Widget send_state to prevent
+        an unnecessary initial state message.
+        """
+        pass

--- a/kernel-python/urth/widgets/widget_channels.py
+++ b/kernel-python/urth/widgets/widget_channels.py
@@ -1,15 +1,15 @@
 # Copyright (c) Jupyter Development Team.
 # Distributed under the terms of the Modified BSD License.
 
-from IPython.html import widgets  # Widget definitions
-
 from collections import defaultdict
+
+from .urth_widget import UrthWidget
 
 # Global variable used to store the current Channels instance
 the_channels = None
 
 
-class Channels(widgets.Widget):
+class Channels(UrthWidget):
     """ A widget that provides an API for setting bound channel variables. """
 
     def __init__(self, value=None, **kwargs):

--- a/kernel-python/urth/widgets/widget_dataframe.py
+++ b/kernel-python/urth/widgets/widget_dataframe.py
@@ -1,14 +1,14 @@
 # Copyright (c) Jupyter Development Team.
 # Distributed under the terms of the Modified BSD License.
 
-from IPython.html import widgets # Widget definitions
 from IPython.utils.traitlets import * # Used to declare attributes of our widget
 from IPython.core.getipython import get_ipython
 
 from urth.util.serializer import Serializer
+from .urth_widget import UrthWidget
 
 
-class DataFrame(widgets.Widget):
+class DataFrame(UrthWidget):
     """
     A widget for retrieving the value of a DataFrame in the kernel.
     """

--- a/kernel-python/urth/widgets/widget_function.py
+++ b/kernel-python/urth/widgets/widget_function.py
@@ -3,15 +3,15 @@
 
 import inspect
 
-from IPython.html import widgets # Widget definitions
 from IPython.utils.traitlets import Integer, Unicode # Used to declare attributes of our widget
 from IPython.core.getipython import get_ipython
 
 from urth.util.serializer import Serializer
 from urth.util.functions import apply_with_conversion, signature_spec
+from .urth_widget import UrthWidget
 
 
-class Function(widgets.Widget):
+class Function(UrthWidget):
     """
     A Widget for invoking a function on the kernel.
     """


### PR DESCRIPTION
This PR fixes #7 and #17 by suppressing onModelChange calls during syncing and preventing an unnecessary Python sync message from being sent upon widget creation.
