### PR TITLE
Skip remote tests if SAUCE* environment variables not defined.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -144,8 +144,12 @@ test-js: | $(URTH_COMP_LINKS)
 	@npm run test
 
 test-js-remote: | $(URTH_COMP_LINKS)
+ifdef SAUCE_USER_NAME
 	@echo 'Running web component tests remotely on Sauce Labs...'
 	@npm run test-sauce --silent -- --sauce-username $(SAUCE_USER_NAME) --sauce-access-key $(SAUCE_ACCESS_KEY)
+else
+	@echo 'No SAUCE environment variables found, skipping remote web component tests'
+endif
 
 test-py: REPO?=jupyter/pyspark-notebook:3.2
 test-py: dist/urth


### PR DESCRIPTION
Made a change to the Makefile to skip remote js testing if the SAUCE\* environment variables are not defined. This is a temporary fix to allow builds to pass on pull requests. I will open an issue to get the tests working on Firefox, in which case we should be able to use the `xvfb` environment in Travis.
