### PR TITLE
Support refreshing the function signature.

### DIFF
--- a/elements/urth-core-behaviors/dynamic-properties-behavior.html
+++ b/elements/urth-core-behaviors/dynamic-properties-behavior.html
@@ -1,0 +1,109 @@
+<!--
+# Copyright (c) Jupyter Development Team.
+# Distributed under the terms of the Modified BSD License.
+-->
+
+<script>
+    'use strict';
+    (function() {
+        window.Urth = window.Urth || {};
+
+        /**
+         * Behavior that allows a Polymer element to define new properties at runtime. To
+         * support this, several methods from Polymer.Bind were copied and redefined.
+         *
+         * @group Urth Core
+         * @polymerBehavior Urth.DynamicPropertiesBehavior
+         */
+        Urth.DynamicPropertiesBehavior = {
+
+            /**
+             * Adds the specified properties to this instance of an element. The
+             * dynProps parameter is in the same format as the `properties` object used
+             * in defining new Polymer elements.
+             *
+             * @param dynProps - Object with properties to add
+             * @method addDynamicProperties
+             */
+            addDynamicProperties: function(dynProps){
+                this._dynamicProperties = dynProps;
+                this._addPropertyEffects(dynProps);
+                this.__createBindings(dynProps);
+            },
+
+            /**
+             * Removes all dynamic properties added to this element.
+             *
+             * @method resetDynamicProperties
+             */
+            resetDynamicProperties: function(){
+                // copy the properties from the prototype
+                this._propertyEffects = {};
+                this.mixin(this._propertyEffects, this.constructor.prototype._propertyEffects);
+
+                // delete existing dynamic properties from this object
+                var propsToRemove =  this._dynamicProperties || {};
+                Object.keys(propsToRemove).forEach(function(prop){
+                    delete this[prop];
+                }.bind(this));
+
+                delete this._dynamicProperties;
+            },
+
+            /*
+             * Modified from Polymer.Bind.createBindings to allow only createBindings the
+             * given properties and to call our __createAccessors function.
+             */
+            __createBindings: function(dynProps) {
+                //console.group(model.is);
+                // map of properties to effects
+                var fx$ = this._propertyEffects;
+                if (fx$) {
+                    // for each property with effects
+                    for (var n in fx$) {
+
+                        if( dynProps[n] ){
+                            // array of effects
+                            var fx = fx$[n];
+                            // effects have priority
+                            fx.sort(this._sortPropertyEffects);
+
+                            // create accessors
+                            this.__createAccessors(n, fx);
+                        }
+                    }
+                }
+                //console.groupEnd();
+            },
+
+            /*
+             * Modified to add `configurable` to the descriptor object to allow for
+             * deletion of dynamically added properties.
+             * see http://stackoverflow.com/questions/7141210/how-do-i-undo-a-object-defineproperty-call
+             */
+            __createAccessors: function(property, effects){
+                var defun = {
+                    get: function() {
+                        return this.__data__[property];
+                    },
+                    configurable: true //necessary to allow for a delete
+                };
+                var setter = function(value) {
+                    this._propertySetter(property, value, effects);
+                };
+                var info = this.getPropertyInfo && this.getPropertyInfo(property);
+                if (info && info.readOnly) {
+                    if (!info.computed) {
+                        this['_set' + Polymer.Bind.upper(property)] = setter;
+                    }
+                }
+                else {
+                    defun.set = setter;
+                }
+
+                Object.defineProperty(this, property, defun)
+            },
+
+        };
+    })();
+</script>

--- a/elements/urth-core-function/test/urth-core-function.html
+++ b/elements/urth-core-function/test/urth-core-function.html
@@ -20,6 +20,7 @@
 
     <!-- STEP 2: Import the element to test. -->
     <link rel='import' href='../../urth-core-behaviors/jupyter-widget-behavior.html'>
+
     <script>
         //mock Urth.JupyterWidgetBehavior
         sinon.stub(Urth.JupyterWidgetBehavior, "createModel");
@@ -514,6 +515,54 @@
 
                 expect(_tryInvoke.callCount).to.equal(0);
             });
+
+            it('should handle multiple signature changes', function() {
+                var fElmt = fixture('basic');
+
+                fElmt._onSignatureChange({
+                    x: {}
+                });
+
+                fElmt._onSignatureChange({
+                    x: {'value': 3}
+                });
+
+                expect(fElmt.hasOwnProperty('argX')).to.be.true;
+                expect(fElmt.argX).to.equal(3);
+            });
+
+            it('should add new argument properties in the new signature', function() {
+                var fElmt = fixture('basic');
+
+                fElmt._onSignatureChange({
+                    x: {}
+                });
+
+                fElmt._onSignatureChange({
+                    x: {},
+                    y: {}
+                });
+
+                expect(fElmt.hasOwnProperty('argX')).to.be.true;
+                expect(fElmt.hasOwnProperty('argY')).to.be.true;
+            });
+
+            it('should remove an argument property if it is not in the new signature', function(){
+                var fElmt = fixture('basic');
+
+                fElmt._onSignatureChange({
+                    x: {},
+                    y: {}
+                });
+
+                fElmt._onSignatureChange({
+                    x: {}
+                });
+
+                expect(fElmt.hasOwnProperty('argX')).to.be.true;
+                expect(fElmt.hasOwnProperty('argY')).to.be.false;
+            });
+
         });
 
         describe('invoke', function() {

--- a/elements/urth-core-function/urth-core-function.html
+++ b/elements/urth-core-function/urth-core-function.html
@@ -4,6 +4,7 @@
 -->
 <link rel="import" href="../polymer/polymer.html">
 <link rel="import" href="../urth-core-behaviors/jupyter-widget-behavior.html">
+<link rel='import' href='../urth-core-behaviors/dynamic-properties-behavior.html'>
 
 <!--
 Creates a client side proxy to a function defined in the kernel. This function is specified by
@@ -126,10 +127,15 @@ Both examples are equivalent to invoking `aFunction(x=5, y=4)`
                     readOnly: true,
                     computed: '_computeReady(args.*, signature)',
                     notify: true
-                }
+                },
+
             },
 
-            behaviors: [Urth.JupyterWidgetBehavior],
+            behaviors: [
+                Urth.JupyterWidgetBehavior,
+                Urth.ExecutionCompleteBehavior,
+                Urth.DynamicPropertiesBehavior
+            ],
 
             observers: [
                 '_onArgsPropertyChanged(args.*)'
@@ -203,6 +209,10 @@ Both examples are equivalent to invoking `aFunction(x=5, y=4)`
 
                     }
                 }
+            },
+
+            _onExecutionComplete: function(){
+                this.refresh();
             },
 
             _syncParamAttributes: function( params ){
@@ -343,11 +353,12 @@ Both examples are equivalent to invoking `aFunction(x=5, y=4)`
              * This method handles changes to the signature of the method. It will create a new property based on
              * the name of the parameter. These new properties will allow data binding and will be kept in sync with
              * the contents of the `args` property.
+             *
              */
             _onSignatureChange: function(sig){
                 console.debug('urth-core-function _onSignatureChange got new signature', sig);
 
-                this._resetProperties();
+                this.resetDynamicProperties();
 
                 var paramNames = Object.keys(sig);
                 if( paramNames.length > 0 ){
@@ -369,7 +380,7 @@ Both examples are equivalent to invoking `aFunction(x=5, y=4)`
 
                     }.bind(this));
 
-                    this._addProperties(paramProperties);
+                    this.addDynamicProperties(paramProperties);
 
                     //set the defaults values and sync if necessary
                     var paramsToSync = {};
@@ -397,15 +408,15 @@ Both examples are equivalent to invoking `aFunction(x=5, y=4)`
                 }
             },
 
-            _resetProperties: function(){
-                //need to copy the properties from the prototype
-                this._propertyEffects = {};
-                this.mixin(this._propertyEffects, this.constructor.prototype._propertyEffects);
-            },
-
-            _addProperties: function(properties){
-                this._addPropertyEffects(properties);
-                Polymer.Bind.createBindings(this);
+            /**
+             * Update the `signature` held by this element with
+             * the function signature's current state on the kernel.
+             *
+             * @method refresh
+             */
+            refresh: function() {
+                console.debug("urth-core-function sending sync message...");
+                this.send({ "event": "sync" });
             },
 
             _createArgChangeHandler: function(param){

--- a/elements/urth-core-function/urth-core-function.html
+++ b/elements/urth-core-function/urth-core-function.html
@@ -74,7 +74,8 @@ Both examples are equivalent to invoking `aFunction(x=5, y=4)`
 
                 /**
                  * Controls if the function is invoked automatically on any change to
-                 * its parameters.
+                 * its parameters, and whether the `signature` is refreshed
+                 * after each code execution.
                  *
                  * @attribute auto
                  * @type Boolean
@@ -212,7 +213,9 @@ Both examples are equivalent to invoking `aFunction(x=5, y=4)`
             },
 
             _onExecutionComplete: function(){
-                this.refresh();
+                if (this.auto) {
+                    this.refresh();
+                }
             },
 
             _syncParamAttributes: function( params ){

--- a/kernel-scala/src/main/scala/urth/widgets/WidgetFunction.scala
+++ b/kernel-scala/src/main/scala/urth/widgets/WidgetFunction.scala
@@ -55,6 +55,8 @@ class WidgetFunction(comm: CommWriter)
     (msgContent \ Comm.KeyEvent).asOpt[String] match {
       case Some(Comm.EventInvoke) =>
         handleInvoke(msgContent, this.theFunctionName, this.limit)
+      case Some(Comm.EventSync) =>
+        sendSignature(this.theFunctionName)
       case Some(evt) =>
         logger.warn(s"Unhandled custom event ${evt}.")
       case None =>

--- a/kernel-scala/src/test/scala/urth/widgets/WidgetFunctionSpec.scala
+++ b/kernel-scala/src/test/scala/urth/widgets/WidgetFunctionSpec.scala
@@ -21,14 +21,14 @@ class WidgetFunctionSpec extends FunSpec with Matchers with MockitoSugar {
     override def handleInvoke(msg: MsgData, name: String, limit: Int) = ()
   }
 
-  class TestWidgetNoArgSpec(comm: CommWriter) extends WidgetFunction(comm) {
+  class TestWidgetNoSignature(comm: CommWriter) extends WidgetFunction(comm) {
     override def sendSignature(name: String) = ()
   }
 
   describe("WidgetFunction"){
     describe("#handleBackbone") {
       it("should register a function name and send the signature") {
-        val test = spy(new TestWidgetNoArgSpec(mock[CommWriter]))
+        val test = spy(new TestWidgetNoSignature(mock[CommWriter]))
         val msg = Json.obj(Comm.KeySyncData -> Map(Comm.KeyFunctionName -> "f"))
         test.handleBackbone(msg)
         verify(test).registerFunction("f")
@@ -67,6 +67,16 @@ class WidgetFunctionSpec extends FunSpec with Matchers with MockitoSugar {
         val msg = Json.obj(Comm.KeyEvent -> Comm.EventInvoke)
         test.handleCustom(msg)
         verify(test).handleInvoke(msg, "f", 100)
+      }
+
+      it("should send the current signature on a sync event") {
+        val test = spy(new TestWidgetNoSignature(mock[CommWriter]))
+
+        test.registerFunction("f")
+
+        val msg = Json.obj(Comm.KeyEvent -> Comm.EventSync)
+        test.handleCustom(msg)
+        verify(test).sendSignature("f")
       }
 
       it("should not handle an invalid event") {


### PR DESCRIPTION
This closes #4 - the `urth-core-function` now synchronizes the function signature after each code execution, and updates its properties accordingly.
