### PR TITLE
make selection work with shady dom refs #40

### DIFF
--- a/elements/urth-viz-chart/urth-viz-chart.html
+++ b/elements/urth-viz-chart/urth-viz-chart.html
@@ -312,7 +312,7 @@ The chart accepts data via attribute `datarows` and column headers via attribute
 
                     this.chart[modelProp].dispatch.on('elementClick', function(e) {
                           this.$$('.hover').classList.toggle('selected');
-                          this._setSelection(d3.select(this.shadowRoot).selectAll('.nvd3 .selected').data());
+                          this._setSelection(this._svgSelection(d3).selectAll('.nvd3 .selected').data());
                     }.bind(this));
 
                     return chart;

--- a/notebooks/examples/urth-viz-chart.ipynb
+++ b/notebooks/examples/urth-viz-chart.ipynb
@@ -192,7 +192,7 @@
    "source": [
     "%%html\n",
     "<script>\n",
-    "c1.addEventListener('selection-changed', function(e) { s1.innerText = JSON.stringify(e.detail.value)});\n",
+    "c1.addEventListener('selection-changed', function(e) { s1.textContent = JSON.stringify(e.detail.value)});\n",
     "</script>\n",
     "<p>Selection: <span id=\"s1\"></span></p>"
    ]


### PR DESCRIPTION
This fixes the immediate problem rendering chart on Firefox and using the selection API.  Styling issues continue to exist with how the polyfill applies widget-specific CSS, but that appears to be the same issue as #39 and will be addressed separately.
