### PR TITLE
Error message support

### DIFF
--- a/elements/urth-core-behaviors/jupyter-widget-behavior.html
+++ b/elements/urth-core-behaviors/jupyter-widget-behavior.html
@@ -214,7 +214,7 @@ This behavior is used to encapsulate some of the services needed for ipywidgets.
              * sent from the kernel. The status is "ok" when execution was
              * successful, and "error" when an error occurred.
              */
-            onModelStatusChange: function(newVal){
+            onModel__status__Change: function(newVal){
                 if (newVal.status === "ok"){
                     this._clearErrorMessages();
                 } else {

--- a/elements/urth-core-behaviors/jupyter-widget-behavior.html
+++ b/elements/urth-core-behaviors/jupyter-widget-behavior.html
@@ -6,6 +6,13 @@
 <!--
 This behavior is used to encapsulate some of the services needed for ipywidgets.
 -->
+<style>
+    .output_area pre.urth-widget-error {
+        color: red;
+        background-color: #fdd;
+        padding: 5px;
+    }
+</style>
 <script>
     'use strict';
     (function() {
@@ -200,7 +207,44 @@ This behavior is used to encapsulate some of the services needed for ipywidgets.
              * @method onModelChange
              * @param {Object} options
              */
-            onModelChange: function(options){}
+            onModelChange: function(options){},
+
+            /**
+             * Clears or displays error messages according to the status
+             * sent from the kernel. The status is "ok" when execution was
+             * successful, and "error" when an error occurred.
+             */
+            onModelStatusChange: function(newVal){
+                if (newVal.status === "ok"){
+                    this._clearErrorMessages();
+                } else {
+                    this.displayErrorMessage(newVal.msg);
+                }
+            },
+
+            _clearErrorMessages: function(){
+                var errs = this.getElementsByClassName("urth-widget-error");
+                var numErrs = errs.length;
+                for (var i = 0; i < numErrs; i++){
+                    this.removeChild(errs[0]);
+                }
+            },
+
+            /**
+             * Displays the given error message in the output area associated
+             * with this widget.
+             *
+             * @method displayErrorMessage
+             * @param String msg
+             */
+            displayErrorMessage: function(msg){
+                var errorNode = document.createElement("pre")
+                errorNode.innerHTML = msg;
+                errorNode.classList.add("urth-widget-error");
+                this.appendChild(errorNode);
+                var widgetName = this.nodeName.toLowerCase();
+                console.error(widgetName + ": " + msg);
+            }
         };
     })();
 </script>

--- a/elements/urth-core-behaviors/test/jupyter-widget-behavior.html
+++ b/elements/urth-core-behaviors/test/jupyter-widget-behavior.html
@@ -56,6 +56,41 @@
 
         });
 
+        describe('_onModelStatusChange', function() {
+            it('should call _clearErrorMessages on status ok', function() {
+                var optionFixture = {
+                    status: "ok"
+                }
+
+                var testObject = Polymer.Base.mixin({
+                    _clearErrorMessages: function(){}
+                }, Urth.JupyterWidgetBehavior);
+
+                var clearFunc = sinon.stub(testObject, "_clearErrorMessages");
+
+                testObject.onModelStatusChange(optionFixture);
+
+                assert(clearFunc.calledOnce, "_clearErrorMessages was called " + clearFunc.callCount);
+            });
+
+            it('should call displayErrorMessage on status error', function() {
+                var optionFixture = {
+                    status: "error"
+                }
+
+                var testObject = Polymer.Base.mixin({
+                    displayErrorMessage:function(){}
+                }, Urth.JupyterWidgetBehavior);
+
+                var displayFunc = sinon.stub(testObject, "displayErrorMessage");
+
+                testObject.onModelStatusChange(optionFixture);
+
+                assert(displayFunc.calledOnce, "displayErrorMessage was called " + displayFunc.callCount);
+            });
+
+        });
+
         describe('sync', function() {
             it('should call set on the model on each property and save changes', function() {
 

--- a/elements/urth-core-behaviors/test/jupyter-widget-behavior.html
+++ b/elements/urth-core-behaviors/test/jupyter-widget-behavior.html
@@ -56,7 +56,7 @@
 
         });
 
-        describe('_onModelStatusChange', function() {
+        describe('onModel__status__Change', function() {
             it('should call _clearErrorMessages on status ok', function() {
                 var optionFixture = {
                     status: "ok"
@@ -68,7 +68,7 @@
 
                 var clearFunc = sinon.stub(testObject, "_clearErrorMessages");
 
-                testObject.onModelStatusChange(optionFixture);
+                testObject.onModel__status__Change(optionFixture);
 
                 assert(clearFunc.calledOnce, "_clearErrorMessages was called " + clearFunc.callCount);
             });
@@ -84,7 +84,7 @@
 
                 var displayFunc = sinon.stub(testObject, "displayErrorMessage");
 
-                testObject.onModelStatusChange(optionFixture);
+                testObject.onModel__status__Change(optionFixture);
 
                 assert(displayFunc.calledOnce, "displayErrorMessage was called " + displayFunc.callCount);
             });

--- a/elements/urth-core-channels/test/urth-core-channels.html
+++ b/elements/urth-core-channels/test/urth-core-channels.html
@@ -533,7 +533,7 @@
         describe('onModelChange', function(){
 
             it('should call _handleItemChangeMessage with right path and value', function(){
-                var _handleItemChangeMessage = sinon.spy(channel, '_handleItemChangeMessage');
+                var _handleItemChangeMessage = sinon.stub(channel, '_handleItemChangeMessage');
 
                 channel.onModelChange({
                     changed: {
@@ -557,12 +557,12 @@
             it('should call setItem with the right name, value and channel', function(){
                 var setItem = sinon.spy(channel, 'setItem');
 
-                channel._handleItemChangeMessage("aChannel:aName", "a value");
+                channel._handleItemChangeMessage("a:aName", "a value");
 
                 assert(setItem.calledOnce, "Method was called " + setItem.callCount + " expected 1");
                 expect(setItem.getCall(0).args[0]).to.equal('aName');
                 expect(setItem.getCall(0).args[1]).to.equal('a value');
-                expect(setItem.getCall(0).args[2]).to.equal('aChannel');
+                expect(setItem.getCall(0).args[2]).to.equal('a');
             });
 
         });

--- a/elements/urth-core-channels/test/urth-core-channels.html
+++ b/elements/urth-core-channels/test/urth-core-channels.html
@@ -537,19 +537,34 @@
 
                 channel.onModelChange({
                     changed: {
-                        "one": 1,
-                        "two": 2
+                        "one:one": 1,
+                        "two:two": 2
                     }
                 });
 
                 assert(_handleItemChangeMessage.calledTwice, "Method was called " + _handleItemChangeMessage.callCount + " expected 2");
-                expect(_handleItemChangeMessage.getCall(0).args[0]).to.equal('one');
+                expect(_handleItemChangeMessage.getCall(0).args[0]).to.equal('one:one');
                 expect(_handleItemChangeMessage.getCall(0).args[1]).to.equal(1);
 
-                expect(_handleItemChangeMessage.getCall(1).args[0]).to.equal('two');
+                expect(_handleItemChangeMessage.getCall(1).args[0]).to.equal('two:two');
                 expect(_handleItemChangeMessage.getCall(1).args[1]).to.equal(2);
             });
 
+            it('should not call _handleItemChangeMessage with invalid paths', function() {
+                var _handleItemChangeMessage = sinon.stub(channel, '_handleItemChangeMessage');
+
+                channel.onModelChange({
+                    changed: {
+                        "one:one": 1,
+                        "foo": 2
+                    }
+                });
+
+                assert(_handleItemChangeMessage.calledOnce, "Method was called " + _handleItemChangeMessage.callCount + " expected 1");
+                expect(_handleItemChangeMessage.getCall(0).args[0]).to.equal("one:one");
+                expect(_handleItemChangeMessage.getCall(0).args[1]).to.equal(1);
+
+            });
         });
 
         describe('_handleItemChangeMessage', function(){

--- a/elements/urth-core-channels/urth-core-channels.html
+++ b/elements/urth-core-channels/urth-core-channels.html
@@ -105,9 +105,11 @@ dataChannel.setItem('user', 'Luke');
             console.debug('urth-core-channels onModelChange', options);
 
             var changes = options.changed;
-            Object.keys(changes).forEach(function(change){
+            Object.keys(changes).filter(function(change){
+                return !(change === "status");
+            }).forEach(function(change){
                 console.debug('urth-core-channels onModelChange changed ', change, changes[change]);
-                this._handleItemChangeMessage(change, changes[change])
+                this._handleItemChangeMessage(change, changes[change]);
             }.bind(this));
         },
 
@@ -127,7 +129,11 @@ dataChannel.setItem('user', 'Luke');
          */
         _handleItemChangeMessage: function( path, value ){
             var path = path.split(':');
-            this.setItem(path[1], value, path[0]);
+            if (!this._getChannel(path[0])){
+                this.displayErrorMessage("Channel " + path[0] + " does not exist.");
+            } else {
+                this.setItem(path[1], value, path[0]);
+            }
         }
     });
 </script>

--- a/elements/urth-core-channels/urth-core-channels.html
+++ b/elements/urth-core-channels/urth-core-channels.html
@@ -106,8 +106,8 @@ dataChannel.setItem('user', 'Luke');
 
             var changes = options.changed;
             Object.keys(changes).filter(function(change){
-                return !(change === "status");
-            }).forEach(function(change){
+                return this.__validPath(change);
+            }.bind(this)).forEach(function(change){
                 console.debug('urth-core-channels onModelChange changed ', change, changes[change]);
                 this._handleItemChangeMessage(change, changes[change]);
             }.bind(this));
@@ -124,16 +124,20 @@ dataChannel.setItem('user', 'Luke');
         },
 
         /**
+         * Decides whether the given string is valid for use in _handleItemChangeMessage
+         **/
+        __validPath: function(path){
+            var pathRegex = RegExp("[a-zA-Z_0-9]+:[a-zA-Z_0-9]+");
+            return pathRegex.exec(path);
+        },
+
+        /**
          * Handle an item change represented by the given path and value.
          * The path is of the form <CHANNEL_NAME>:<ITEM_NAME>, e.g. "c:user".
          */
         _handleItemChangeMessage: function( path, value ){
             var path = path.split(':');
-            if (!this._getChannel(path[0])){
-                this.displayErrorMessage("Channel " + path[0] + " does not exist.");
-            } else {
-                this.setItem(path[1], value, path[0]);
-            }
+            this.setItem(path[1], value, path[0]);
         }
     });
 </script>

--- a/elements/urth-core-function/urth-core-function.html
+++ b/elements/urth-core-function/urth-core-function.html
@@ -458,7 +458,7 @@ Both examples are equivalent to invoking `aFunction(x=5, y=4)`
                     this.invoke(true);
                 }
                 else{
-                    console.warn('urth-core-function tried to invoke by arguments are not in valid state', this.args);
+                    console.warn('urth-core-function tried to invoke but arguments are not in valid state', this.args);
                 }
             },
 

--- a/kernel-python/urth/widgets/tests/test_widget_channels.py
+++ b/kernel-python/urth/widgets/tests/test_widget_channels.py
@@ -15,6 +15,7 @@ class TestWidgetChannels(unittest.TestCase):
     def setUp(self):
         comm = Mock(spec=Comm)
         self.widget = Channels(comm=comm)
+
         self.chan = 'c'
         self.name = 'x'
 
@@ -64,4 +65,20 @@ class TestWidgetChannels(unittest.TestCase):
         self.msg['data']['new_val'] = {"b": "c"}
         self.widget._handle_change_msg(None, self.msg)
         self.assertEqual(self.lst, [{"a": 1}, {"b": "c"}])
+
+    #### _handle_change_msg()
+    def test_handle_change_msg_invoke_error(self):
+        """should send an error message when handler invocation fails"""
+        self.widget.error = lambda msg: self.lst.append('err')
+        explosion = lambda x, y: 1 / 0
+        self.widget.watch(self.name, explosion, self.chan)
+        self.widget._handle_change_msg(None, self.msg)
+        self.assertEqual(self.lst, ['err'])
+
+    def test_hand_change_msg_invoke_success(self):
+        """should send an ok message when handler invocation succeeds"""
+        self.widget.ok = lambda: self.lst.append('ok')
+        self.widget.watch(self.name, self.handler, self.chan)
+        self.widget._handle_change_msg(None, self.msg)
+        self.assertEqual(self.lst, [1, 2, 'ok'])
 

--- a/kernel-python/urth/widgets/urth_exception.py
+++ b/kernel-python/urth/widgets/urth_exception.py
@@ -1,0 +1,14 @@
+# Copyright (c) Jupyter Development Team.
+# Distributed under the terms of the Modified BSD License.
+
+
+class UrthException(Exception):
+    """
+    A generic exception for Urth Widgets.
+    """
+
+    def __init__(self, msg):
+        self.msg = msg
+
+    def __str__(self):
+        return self.msg

--- a/kernel-python/urth/widgets/urth_widget.py
+++ b/kernel-python/urth/widgets/urth_widget.py
@@ -43,7 +43,7 @@ class UrthWidget(widgets.Widget):
         self._send({
             "method": "update",
             "state": {
-                "status": {
+                "__status__": {
                     "status": status,
                     "msg": msg,
                     "timestamp": round(time.time() * 1000)

--- a/kernel-python/urth/widgets/urth_widget.py
+++ b/kernel-python/urth/widgets/urth_widget.py
@@ -1,5 +1,6 @@
 # Copyright (c) Jupyter Development Team.
 # Distributed under the terms of the Modified BSD License.
+import time
 
 from IPython.html import widgets  # Widget definitions
 
@@ -15,3 +16,57 @@ class UrthWidget(widgets.Widget):
         an unnecessary initial state message.
         """
         pass
+
+    def _send_update(self, attribute, value):
+        """
+        Sends a message to update the front-end state of the given attribute.
+        """
+        msg = {
+            "method": "update",
+            "state": {
+                attribute: value
+            }
+        }
+        self._send(msg)
+
+    def send_status(self, status, msg=""):
+        """
+        Sends a message to inform the front-end of the execution status.
+
+        Parameters
+        ----------
+        status : string
+            "ok" for success, "error" for failure.
+        msg : string
+            Message accompanying the status, e.g. an error message.
+        """
+        self._send({
+            "method": "update",
+            "state": {
+                "status": {
+                    "status": status,
+                    "msg": msg,
+                    "timestamp": round(time.time() * 1000)
+                }
+            }
+        })
+
+    def error(self, msg):
+        """
+        Inform the front-end that an error occurred, with the given error msg.
+        Parameters
+        ----------
+        msg : string
+            An error message.
+        """
+        self.send_status("error", msg)
+
+    def ok(self, msg=""):
+        """
+        Inform the front-end that processing succeeded.
+        Parameters
+        ----------
+        msg : string
+            An optional message.
+        """
+        self.send_status("ok", msg)

--- a/kernel-python/urth/widgets/widget_channels.py
+++ b/kernel-python/urth/widgets/widget_channels.py
@@ -50,20 +50,19 @@ class Channels(UrthWidget):
                     handler = chan_handlers[data['name']]
                     old = data.get('old_val', None)
                     new = data.get('new_val', None)
-                    handler(old, new)
+                    try:
+                        handler(old, new)
+                        self.ok()
+                    except Exception as e:
+                        self.error("Error executing watch handler for {} on "
+                                   "channel {}: {}".format(
+                                    data['name'], data['channel'], str(e)))
                 else:
-                    print("No watch handler for name field in {}".format(data))
+                    print("No watch handler for name field in {}".format(
+                        data))
             else:
-                print("No watch handler for channel field in {}".format(data))
-
-    def _send_update(self, attribute, value):
-        msg = {
-            "method": "update",
-            "state": {
-                attribute: value
-            }
-        }
-        self._send(msg)
+                print("No watch handler for channel field in {}".format(
+                    data))
 
 
 class Channel:

--- a/kernel-scala/src/main/scala/urth/widgets/Widget.scala
+++ b/kernel-scala/src/main/scala/urth/widgets/Widget.scala
@@ -103,6 +103,18 @@ abstract class Widget(comm: CommWriter) extends LogLike with MessageSupport {
   def sendState(key: String, value: JsValue): Unit = sendState(comm, key, value)
 
   /**
+   * Send a status error message to the front-end with the given message.
+   * @param msg An error message.
+   */
+  def sendError(msg: String) = sendStatus(comm, Comm.StatusError, msg)
+
+  /**
+   * Send a status ok message to the front-end with the given message.
+   * @param msg An optional status message.
+   */
+  def sendOk(msg: String = "") = sendStatus(comm, Comm.StatusOk, msg)
+
+  /**
    * Handles a Comm Message whose method is backbone.
    * @param msg The Comm Message.
    */

--- a/kernel-scala/src/main/scala/urth/widgets/WidgetFunction.scala
+++ b/kernel-scala/src/main/scala/urth/widgets/WidgetFunction.scala
@@ -10,6 +10,8 @@ import com.ibm.spark.kernel.protocol.v5.MsgData
 import play.api.libs.json.{JsString, JsValue, Json}
 import urth.widgets.util.{SerializationSupport, StandardFunctionSupport}
 
+import scala.util.{Failure, Success, Try}
+
 /**
  * A widget for invoking a function in the kernel.
  *
@@ -67,13 +69,13 @@ class WidgetFunction(comm: CommWriter)
     logger.debug(s"Handling invoke message ${msg}...")
     (msg \ Comm.KeyArgs).asOpt[JsValue] match {
       case Some(args) =>
-        invokeFunc(name, args).map(serialize(_, limit)) match {
-          case Some(result) =>
+        invokeFunc(name, args, limit) match {
+          case Success(result) =>
             sendResult(result)
             sendOk()
-          case None =>
-            sendError(s"No result for ${theFunctionName} invoke.")
-            logger.error(s"No result for ${theFunctionName} invoke.")
+          case Failure(t) =>
+            sendError(s"Error invoking ${theFunctionName}: ${t.getCause}")
+            logger.error(s"Error invoking ${theFunctionName}: ${t.getCause}")
         }
       case None =>
         sendError(s"No arguments were provided in message $msg for invocation!")
@@ -81,14 +83,14 @@ class WidgetFunction(comm: CommWriter)
     }
   }
 
-  private[widgets] def invokeFunc(funcName: String, args: JsValue): Option[Any] = {
+  private[widgets] def invokeFunc(funcName: String, args: JsValue, limit: Int = limit): Try[JsValue] = {
     logger.debug(s"Invoking registered function with args ${args}")
-    val result = for {
-      map <- argMap(args)
-      res <- invokeFunction(funcName, map)
-    } yield res
-    logger.debug(s"Function invocation result: ${result}")
-    result
+    argMap(args) match {
+      case Some(map) => invokeFunction(funcName, map) map (serialize(_, limit))
+      case None => throw new RuntimeException(
+          s"Invalid arguments $args for function $funcName"
+      )
+    }
   }
 
   private def argMap(args: JsValue): Option[Map[String, String]] =

--- a/kernel-scala/src/main/scala/urth/widgets/package.scala
+++ b/kernel-scala/src/main/scala/urth/widgets/package.scala
@@ -36,6 +36,7 @@ package object widgets {
     val KeyRequired      = "required"
     val KeyDefaultValue  = "value"
     val KeyStatus        = "status"
+    val KeyStatusMsg     = "__status__"
     val KeyMessage       = "msg"
     val KeyTimestamp     = "timestamp"
 
@@ -64,6 +65,11 @@ package object widgets {
     // Status types
     val StatusError      = "error"
     val StatusOk         = "ok"
+  }
+
+  object SymbolKind {
+    val Method = "method"
+    val Value = "value"
   }
 
   object Default {

--- a/kernel-scala/src/main/scala/urth/widgets/package.scala
+++ b/kernel-scala/src/main/scala/urth/widgets/package.scala
@@ -35,6 +35,9 @@ package object widgets {
     val KeyType          = "type"
     val KeyRequired      = "required"
     val KeyDefaultValue  = "value"
+    val KeyStatus        = "status"
+    val KeyMessage       = "msg"
+    val KeyTimestamp     = "timestamp"
 
     // Method types
     val MethodBackbone   = "backbone"
@@ -57,6 +60,10 @@ package object widgets {
     val ChangeName       = "name"
     val ChangeOldVal     = "old_val"
     val ChangeNewVal     = "new_val"
+
+    // Status types
+    val StatusError      = "error"
+    val StatusOk         = "ok"
   }
 
   object Default {

--- a/kernel-scala/src/main/scala/urth/widgets/util/MessageSupport.scala
+++ b/kernel-scala/src/main/scala/urth/widgets/util/MessageSupport.scala
@@ -28,10 +28,27 @@ trait MessageSupport extends LogLike {
   }
 
   /**
+   * Send a status update with the given status and message.
+   * @param comm CommWriter to use for communication.
+   * @param status "ok" or "error"
+   * @param msg Optional status message, e.g. an error message.
+   */
+  def sendStatus(comm: CommWriter, status: String, msg: String = ""): Unit = {
+    val statusJson = Json.obj(
+      Comm.KeyStatus -> status,
+      Comm.KeyMessage -> msg,
+      Comm.KeyTimestamp -> timestamp
+    )
+    sendState(comm, Comm.KeyStatus, statusJson)
+  }
+
+  /**
    * Send a JSON message using the given comm writer.
    * @param comm CommWriter to use for communication.
    * @param msg Message to send.
    */
   def send(comm: CommWriter, msg: JsValue): Unit = comm.writeMsg(msg)
+
+  private[util] def timestamp: Long = System.currentTimeMillis()
 
 }

--- a/kernel-scala/src/main/scala/urth/widgets/util/MessageSupport.scala
+++ b/kernel-scala/src/main/scala/urth/widgets/util/MessageSupport.scala
@@ -39,7 +39,7 @@ trait MessageSupport extends LogLike {
       Comm.KeyMessage -> msg,
       Comm.KeyTimestamp -> timestamp
     )
-    sendState(comm, Comm.KeyStatus, statusJson)
+    sendState(comm, Comm.KeyStatusMsg, statusJson)
   }
 
   /**

--- a/kernel-scala/src/test/scala/urth/widgets/WidgetDataFrameSpec.scala
+++ b/kernel-scala/src/test/scala/urth/widgets/WidgetDataFrameSpec.scala
@@ -23,6 +23,10 @@ class WidgetDataFrameSpec extends FunSpec with Matchers with MockitoSugar {
       it("should register a dataframe name") {
         val test = spy(new TestWidget(mock[CommWriter]))
         val msg = Json.obj(Comm.KeySyncData -> Map(Comm.KeyDataFrameName -> "df"))
+        val intp = mock[Interpreter]
+        doReturn(Some("")).when(intp).read(anyString())
+        doReturn(intp).when(test).kernelInterpreter
+
         test.handleBackbone(msg)
         verify(test).registerName("df")
       }
@@ -53,9 +57,6 @@ class WidgetDataFrameSpec extends FunSpec with Matchers with MockitoSugar {
       it("should handle a sync event using the current variable name and limit") {
         val test = spy(new TestWidget(mock[CommWriter]))
 
-        test.registerName("df")
-        test.registerLimit(100)
-
         val msg = Json.obj(Comm.KeyEvent -> Comm.EventSync)
 
         val df = ""
@@ -63,19 +64,49 @@ class WidgetDataFrameSpec extends FunSpec with Matchers with MockitoSugar {
         doReturn(Some(df)).when(intp).read(anyString())
         doReturn(intp).when(test).kernelInterpreter
 
+        test.registerLimit(100)
+        test.registerName("df")
+
         test.handleCustom(msg)
-        verify(test).handleSync(test.variableName, test.limit)
+
+        // one from registerName and one from handleCustom
+        val varName = test.variableName
+        val limit = test.limit
+        verify(test, times(2)).serializeAndSend(varName, limit)
       }
 
       it("should not handle an invalid event") {
         val test = spy(new TestWidget(mock[CommWriter]))
         val msg = Json.obj(Comm.KeyEvent -> "asdf")
         test.handleCustom(msg)
-        verify(test, times(0)).handleSync(anyString(), anyInt())
+        verify(test, times(0)).serializeAndSend(anyString(), anyInt())
       }
     }
 
-    describe("#handleSync") {
+    describe("#registerName") {
+      it("should try to serialize and send the DataFrame with the given name"){
+        val test = spy(new TestWidget(mock[CommWriter]))
+        doReturn(Right(())).when(test).serializeAndSend(anyString(), anyInt())
+        test.registerName("foo")
+        verify(test).serializeAndSend("foo", test.limit)
+      }
+
+      it("should send a status ok message if the DataFrame name is valid"){
+        val test = spy(new TestWidget(mock[CommWriter]))
+        doReturn(Right(())).when(test).serializeAndSend(anyString(), anyInt())
+        test.registerName("foo")
+        verify(test).sendOk()
+      }
+
+      it("should send a status error message if the DataFrame name is invalid"){
+        val test = spy(new TestWidget(mock[CommWriter]))
+        doReturn(Left("uh oh")).when(test).serializeAndSend(anyString(), anyInt())
+        test.registerName("foo")
+        verify(test).sendError("uh oh")
+      }
+    }
+
+    describe("#serializeAndSend") {
       it("should serialize the dataframe and send a message when the DataFrame is present") {
         val test = spy(new TestWidget(mock[CommWriter]))
         val msg = Json.obj(Comm.KeyEvent -> Comm.EventSync)
@@ -85,7 +116,7 @@ class WidgetDataFrameSpec extends FunSpec with Matchers with MockitoSugar {
         doReturn(Some(df)).when(intp).read(anyString())
         doReturn(intp).when(test).kernelInterpreter
 
-        test.handleSync("df", 100)
+        test.serializeAndSend("df", 100)
         verify(test).serialize(df, 100)
         verify(test).sendSyncData(any())
       }
@@ -99,7 +130,7 @@ class WidgetDataFrameSpec extends FunSpec with Matchers with MockitoSugar {
         doReturn(None).when(intp).read("df")
         doReturn(intp).when(test).kernelInterpreter
 
-        test.handleSync("df", 100)
+        test.serializeAndSend("df", 100)
         verify(test, times(0)).serialize(any(), anyInt())
         verify(test, times(0)).sendSyncData(any())
       }

--- a/kernel-scala/src/test/scala/urth/widgets/WidgetSpec.scala
+++ b/kernel-scala/src/test/scala/urth/widgets/WidgetSpec.scala
@@ -68,6 +68,24 @@ class WidgetSpec extends FunSpec with Matchers with MockitoSugar {
       }
     }
 
+    describe("#sendError") {
+      it("should send a status error message with the widget's comm") {
+        val comm = mock[CommWriter]
+        val test = spy(new TestWidget(comm))
+        test.sendError("bayud")
+        verify(test).sendStatus(comm, Comm.StatusError, "bayud")
+      }
+    }
+
+    describe("#sendOk") {
+      it("should send a state message with the widget's comm") {
+        val comm = mock[CommWriter]
+        val test = spy(new TestWidget(comm))
+        test.sendOk("goodness")
+        verify(test).sendStatus(comm, Comm.StatusOk, "goodness")
+      }
+    }
+
     describe("#createWidgetInstance") {
       it("should create a function widget when given the function class name") {
         Widget.createWidgetInstance(WidgetClass.Function, mock[CommWriter]).getClass should

--- a/kernel-scala/src/test/scala/urth/widgets/util/MessageSupportSpec.scala
+++ b/kernel-scala/src/test/scala/urth/widgets/util/MessageSupportSpec.scala
@@ -5,10 +5,13 @@ import org.mockito.Mockito._
 import org.scalatest.mock.MockitoSugar
 import org.scalatest.{Matchers, FunSpec}
 import play.api.libs.json.{JsNumber, JsString, Json}
+import urth.widgets.Comm
 
 class MessageSupportSpec extends FunSpec with Matchers with MockitoSugar {
 
-  class TestSupport extends MessageSupport
+  class TestSupport extends MessageSupport {
+    override def timestamp = 0
+  }
 
   describe("#sendState") {
     it("should send a properly formatted update state message") {
@@ -17,6 +20,21 @@ class MessageSupportSpec extends FunSpec with Matchers with MockitoSugar {
       val test = new TestSupport
       test.sendState(comm, "a", JsString("b"))
       verify(comm).writeMsg(expected)
+    }
+  }
+
+  describe("#sendStatus") {
+    it("should send a properly formatted status message") {
+      val expectedData = Json.obj(
+        Comm.KeyStatus -> "status",
+        Comm.KeyMessage -> "message",
+        Comm.KeyTimestamp -> 0
+      )
+      val comm = mock[CommWriter]
+      val test = spy(new TestSupport)
+      test.sendStatus(comm, "status", "message")
+
+      verify(test).sendState(comm, Comm.KeyStatus, expectedData);
     }
   }
 }

--- a/kernel-scala/src/test/scala/urth/widgets/util/MessageSupportSpec.scala
+++ b/kernel-scala/src/test/scala/urth/widgets/util/MessageSupportSpec.scala
@@ -34,7 +34,7 @@ class MessageSupportSpec extends FunSpec with Matchers with MockitoSugar {
       val test = spy(new TestSupport)
       test.sendStatus(comm, "status", "message")
 
-      verify(test).sendState(comm, Comm.KeyStatus, expectedData);
+      verify(test).sendState(comm, Comm.KeyStatusMsg, expectedData);
     }
   }
 }


### PR DESCRIPTION
This PR includes support for displaying error messages that occur during kernel-side widget execution, which closes #5.

To test:

`make test`

**urth-core-function**
- create an `urth-core-function` with a `ref` that doesn't exist
- change the `ref` to a valid function, the error should disappear
- or if set to `auto`, then when the function is defined, the error should disappear
- invoke a function that throws an error, e.g. `def foo(): 1 / 0`

**urth-core-dataframe**
- create an `urth-core-dataframe` with a `ref` that doesn't exist
- if set to `auto`, then when the dataframe is defined, the error should disappear
