### PR TITLE
Remove execution complete callbacks after widget is detached

### DIFF
--- a/elements/urth-core-behaviors/execution-complete-behavior.html
+++ b/elements/urth-core-behaviors/execution-complete-behavior.html
@@ -15,9 +15,20 @@ This Behavior represents the completion of a code cell's execution.
     ready: function() {
       // Code execution defined to be complete when an ExecuteReply is received.
       console.debug("Registering _onExecutionComplete for Execute Reply messages.");
+      this.__replyCallback = this._onExecutionComplete.bind(this);
+
       IPython.notebook.kernel.widget_manager.notebook.events.on(
-        'shell_reply.Kernel', this._onExecutionComplete.bind(this)
+        'shell_reply.Kernel', this.__replyCallback
       );
+    },
+
+    detached: function() {
+        console.debug("Unregistering _onExecutionComplete for Execute Reply messages.");
+        if (this.__replyCallback){
+            IPython.notebook.kernel.widget_manager.notebook.events.off(
+                'shell_reply.Kernel', this.__replyCallback
+            );
+        }
     },
 
     /**

--- a/elements/urth-core-behaviors/jupyter-kernel-observer.html
+++ b/elements/urth-core-behaviors/jupyter-kernel-observer.html
@@ -20,9 +20,24 @@ This behavior is used to implement handlers to kernel events
         Urth.JupyterKernelObserver = {
 
             created: function(){
-                IPython.notebook.events.on('kernel_ready.Kernel', this.onKernelReady.bind(this));
+                console.debug("Registering onKernelReady for Kernel Ready messages.")
+
+                this.__kernelReadyCallback = this.onKernelReady.bind(this);
+                IPython.notebook.events.on(
+                    'kernel_ready.Kernel', this.__kernelReadyCallback
+                );
+
                 if( IPython.notebook.kernel.is_connected() ){
                   this.onKernelReady();
+                }
+            },
+
+            detached: function(){
+                if (this.__kernelReadyCallback) {
+                    console.debug("Unregistering onKernelReady for Kernel Ready messages.")
+                    IPython.notebook.events.off(
+                        'kernel_ready.Kernel', this.__kernelReadyCallback
+                    );
                 }
             },
 

--- a/elements/urth-core-behaviors/jupyter-widget-behavior.html
+++ b/elements/urth-core-behaviors/jupyter-widget-behavior.html
@@ -20,6 +20,11 @@ This behavior is used to encapsulate some of the services needed for ipywidgets.
          */
         Urth.JupyterWidgetBehavior = {
 
+            detached: function() {
+                this._unRegisterModelCallbacks();
+                this._unRegisterNotebookCallbacks();
+            },
+
             /**
              * Creates a backbone model and a comm connection with an instance
              * of the specified kernelClass on the kernel.
@@ -46,9 +51,12 @@ This behavior is used to encapsulate some of the services needed for ipywidgets.
                     }
                 ).then(function(model) {
                         console.log('Model creation successful!', model);
+                        this.__modelChangeCallback = this._onModelChange.bind(this);
+                        this.__commCloseCallback = this._handleCommDisconnect.bind(this);
 
-                        model.on('change', this._onModelChange, this);
-                        model.once('comm:close', this._handleCommDisconnect, this);
+                        model.on('change', this.__modelChangeCallback);
+                        model.once('comm:close', this.__commCloseCallback);
+
                         this.model = model;
                         this.onModelReady();
                     }.bind(this),
@@ -60,10 +68,13 @@ This behavior is used to encapsulate some of the services needed for ipywidgets.
 
             _retryCreateModel: function(){
                 console.debug('Urth.JupyterWidgetBehavior _retryCreateModel - Waiting for another code exec...');
-                IPython.notebook.events.one('shell_reply.Kernel', function(){
-                        console.debug('Urth.JupyterWidgetBehavior createModel - retrying...');
-                        this._doCreateModel();
-                    }.bind(this)
+                this.__shellReplyCallback = function(){
+                    console.debug('Urth.JupyterWidgetBehavior createModel - retrying...');
+                    this._doCreateModel();
+                }.bind(this);
+
+                IPython.notebook.events.one(
+                    'shell_reply.Kernel', this.__shellReplyCallback
                 );
             },
 
@@ -78,6 +89,27 @@ This behavior is used to encapsulate some of the services needed for ipywidgets.
                     }
                 } else {
                     console.error('Urth.JupyterWidgetBehavior no longer retrying createModel!');
+                }
+            },
+
+            /**
+             * Unregister event callbacks associated with the model.
+             */
+            _unRegisterModelCallbacks: function() {
+                if (this.model){
+                    this.model.off('change', this.__modelChangeCallback);
+                    this.model.off('comm:close', this.__commCloseCallback);
+                }
+            },
+
+            /**
+             * Unregister event callbacks associated with the notebook.
+             */
+            _unRegisterNotebookCallbacks: function() {
+                if (this.__shellReplyCallback){
+                    IPython.notebook.events.off(
+                        'shell_reply.Kernel', this.__shellReplyCallback
+                    );
                 }
             },
 

--- a/elements/urth-core-channels/test/urth-core-channels.html
+++ b/elements/urth-core-channels/test/urth-core-channels.html
@@ -24,7 +24,8 @@
     <script>
         //mock Urth.JupyterWidgetBehavior
         sinon.stub(Urth.JupyterWidgetBehavior, "createModel");
-
+        sinon.stub(Urth.JupyterWidgetBehavior, "detached");
+            
         //mock Urth.JupyterKernelObserver
         sinon.stub(Urth.JupyterKernelObserver, "created");
     </script>

--- a/elements/urth-core-dataframe/urth-core-dataframe.html
+++ b/elements/urth-core-dataframe/urth-core-dataframe.html
@@ -4,7 +4,7 @@
 -->
 <link rel="import" href="../polymer/polymer.html">
 <link rel="import" href="../urth-core-behaviors/jupyter-widget-behavior.html">
-<link rel="import" href="execution-complete-behavior.html">
+<link rel="import" href="../urth-core-behaviors/execution-complete-behavior.html">
 
 <!--
 Represents a widget that binds to a DataFrame variable. The DataFrame's

--- a/elements/urth-core-function/test/urth-core-function.html
+++ b/elements/urth-core-function/test/urth-core-function.html
@@ -20,10 +20,13 @@
 
     <!-- STEP 2: Import the element to test. -->
     <link rel='import' href='../../urth-core-behaviors/jupyter-widget-behavior.html'>
+    <link rel='import' href='../../urth-core-behaviors/execution-complete-behavior.html'>
 
     <script>
         //mock Urth.JupyterWidgetBehavior
         sinon.stub(Urth.JupyterWidgetBehavior, "createModel");
+        sinon.stub(Urth.ExecutionCompleteBehavior, "ready");
+        sinon.stub(Urth.ExecutionCompleteBehavior, "detached");
     </script>
     <link rel='import' href='../urth-core-function.html'>
 

--- a/elements/urth-core-function/urth-core-function.html
+++ b/elements/urth-core-function/urth-core-function.html
@@ -5,6 +5,7 @@
 <link rel="import" href="../polymer/polymer.html">
 <link rel="import" href="../urth-core-behaviors/jupyter-widget-behavior.html">
 <link rel='import' href='../urth-core-behaviors/dynamic-properties-behavior.html'>
+<link rel="import" href="../urth-core-behaviors/execution-complete-behavior.html">
 
 <!--
 Creates a client side proxy to a function defined in the kernel. This function is specified by


### PR DESCRIPTION
Fixes #45 

Prevents `sync` messages from being fired for detached widgets
