### PR TITLE
Create channel on setItem to allow initializing template data.

### DIFF
--- a/elements/urth-core-channels/test/urth-core-channels.html
+++ b/elements/urth-core-channels/test/urth-core-channels.html
@@ -357,6 +357,16 @@
 
                 expect(channel.getItem('foo')).to.equal(channel.getItem('foo', 'default'));
             });
+
+            it('should create the given channel if it does not exist', function() {
+                var createChannel = sinon.spy(channel, '_createChannel');
+                var chan = 'DNE';
+                channel.setItem('foo', 'bar', chan);
+
+                assert(createChannel.calledOnce, "_createChannel was called " + createChannel.callCount + " expected 1");
+                expect(createChannel.getCall(0).args[0]).to.equal(chan);
+
+            });
         });
 
         describe('unregister', function() {

--- a/elements/urth-core-channels/urth-core-channels-behavior.html
+++ b/elements/urth-core-channels/urth-core-channels-behavior.html
@@ -106,7 +106,8 @@
 
             /**
              * Sets the value of a key on the channel. Setting a value
-             * will set the property value on all registered elements.
+             * will set the property value on all registered elements. Creates
+             * the channel if it does not exist.
              *
              * @method setItem
              * @param {string} key The key to be associated with the value.
@@ -114,7 +115,7 @@
              * @param {string} channelName The name of the channel to set the value on.
              */
             setItem: function(key, value, channelName) {
-                var channel = this._getChannel(channelName);
+                var channel = this._getOrCreateChannel(channelName);
                 var oldVal = channel && key ? this.getItem(key, channelName) : undefined;
 
                 if (key && channel && oldVal !== value) {
@@ -234,6 +235,11 @@
                 } else {
                     return channels['default'];
                 }
+            },
+
+            _getOrCreateChannel: function(channelName) {
+                var channel = this._getChannel(channelName);
+                return channel ? channel : this._createChannel(channelName);
             },
 
             /**

--- a/elements/urth-core-channels/urth-core-channels.html
+++ b/elements/urth-core-channels/urth-core-channels.html
@@ -118,7 +118,10 @@ dataChannel.setItem('user', 'Luke');
             this.createModel('urth.widgets.widget_channels.Channels', maxRetries);
         },
 
-
+        /**
+         * Handle an item change represented by the given path and value.
+         * The path is of the form <CHANNEL_NAME>:<ITEM_NAME>, e.g. "c:user".
+         */
         _handleItemChangeMessage: function( path, value ){
             var path = path.split(':');
             this.setItem(path[1], value, path[0]);


### PR DESCRIPTION
Fixes #35 

To test:

**Python**

``` python
from urth.widgets.widget_channels import channel
channel('a').set('user', 'Python')
```

``` html
%%html
<template is='urth-core-bind' channel='a'>
    <div>Hello from <span>{{user}}</span></div>
    Name: <input value='{{user::input}}'></input>
</template>
```

**JavaScript**

``` javascript
%%javascript
UrthData.setItem('user', 'foo', 'b');
```

``` html
%%html
<template is='urth-core-bind' channel='b'>
    <div>Hello from <span>{{user}}</span></div>
    Name: <input value='{{user::input}}'></input>
</template>
```
