### PR TITLE
Changes to generally support different Spark Kernel versions

### DIFF
--- a/kernel-scala/src/main/scala/urth/widgets/package.scala
+++ b/kernel-scala/src/main/scala/urth/widgets/package.scala
@@ -5,7 +5,6 @@
 
 package urth
 
-import com.ibm.spark.interpreter.ScalaInterpreter
 import com.ibm.spark.kernel.api.Kernel
 import org.apache.spark.repl.SparkIMain
 
@@ -78,7 +77,9 @@ package object widgets {
     _the_kernel
   }
 
-  def sparkIMain: SparkIMain =
-    getKernel.interpreter.asInstanceOf[ScalaInterpreter].sparkIMain
-
+  def sparkIMain: SparkIMain = {
+    val sparkIMainMethod = getKernel.interpreter.getClass.getMethod("sparkIMain")
+    val sparkIMain = sparkIMainMethod.invoke(getKernel.interpreter).asInstanceOf[org.apache.spark.repl.SparkIMain]
+    sparkIMain
+  }
 }


### PR DESCRIPTION
The Spark Kernel had some package changes that affected our widget support. We modified the code that gets the IMain to use reflexion to avoid getting exposed to package changes and still work across the different versions of the kernel.
