### PR TITLE
Change bower install to be async.

### DIFF
--- a/elements/urth-core-import/urth-core-import.html
+++ b/elements/urth-core-import/urth-core-import.html
@@ -158,6 +158,9 @@
 
                     this.importHref(this.href, function() {
                         this.fire('load');
+                        if (this.debug) {
+                            console.debug(logTag + 'Successfully imported ' + this.href);
+                        }
                     }.bind(this), function(e) {
                         // If the href doesn't load, try to download
                         // the package if it is specified.
@@ -176,9 +179,6 @@
         _onLinkLoad: function() {
             // Save the fact that the link href was loaded successfully.
             loadedPackages[this.href] = true;
-            if (this.debug) {
-                console.debug(logTag + 'Successfully imported ' + this.href);
-            }
         },
 
         _packageChanged: function(newVal, oldVal) {


### PR DESCRIPTION
This commit changes the bower install to be run in a separate thread pool so that it does not block the main thread. The thread pool is set to only contain 1 thread so that the install requests are restricted to one execution at a time. This is necessary to prevent issues that can occur when multiple bower installs of the same package happen concurrently.

The one failing unit test is unrelated to this change set as it is due to one of the indirect project dependencies (paper-input-container) having been updated to depend on changes in Polymer v1.2 (issue #62)

Fixes #43 
