### PR TITLE
Pegging dependency versions to avoid issues due to Polymer 1.2

### DIFF
--- a/elements/urth-viz-chart/bower.json
+++ b/elements/urth-viz-chart/bower.json
@@ -23,8 +23,10 @@
     "polymer": "Polymer/polymer#^1.0.0",
     "paper-item": "PolymerElements/paper-item#^1.0.0",
     "paper-menu": "PolymerElements/paper-menu#^1.0.0",
-    "paper-dropdown-menu": "PolymerElements/paper-dropdown-menu#^1.0.0",
-    "requirejs": "^2.1.0"
+    "requirejs": "^2.1.0",
+
+    "paper-dropdown-menu": "PolymerElements/paper-dropdown-menu#1.0.5",
+    "paper-input": "PolymerElements/paper-input#1.0.16"
   },
   "private": true
 }


### PR DESCRIPTION
Pegged the versions of PolymerElements/paper-input and PolymerElements/paper-dropdown for `urth-viz-chart` to avoid problems introduces by changes to Polymer 1.2.
