### PR TITLE
Allow missing old_val in change messages

### DIFF
--- a/kernel-scala/src/main/scala/urth/widgets/package.scala
+++ b/kernel-scala/src/main/scala/urth/widgets/package.scala
@@ -11,7 +11,7 @@ import org.apache.spark.repl.SparkIMain
 package object widgets {
 
   // Types
-  type WatchHandler = (_, _) => Unit
+  type WatchHandler[T] = (Option[T], T) => Unit
 
   object WidgetClass {
     val Function  = "urth.widgets.widget_function.Function"

--- a/kernel-scala/src/test/scala/urth/widgets/util/FunctionSupportSpec.scala
+++ b/kernel-scala/src/test/scala/urth/widgets/util/FunctionSupportSpec.scala
@@ -414,7 +414,7 @@ class FunctionSupportSpec extends FunSpec with Matchers with MockitoSugar {
         val arg1 = JsNumber(1)
         val arg2 = JsNumber(2)
         var executed = false
-        val handler = (old: Int, noo: Int) => executed = true
+        val handler = (old: Option[Int], noo: Int) => executed = true
 
         support.invokeWatchHandler(arg1, arg2, handler) should be (Some(()))
         executed should be(true)
@@ -423,7 +423,7 @@ class FunctionSupportSpec extends FunSpec with Matchers with MockitoSugar {
       it ("should return None when execution fails"){
         val arg1 = JsNumber(1)
         val arg2 = JsNumber(2)
-        val handler = (old: Int, noo: Int) => { 1 / 0; ()}
+        val handler = (old: Option[Int], noo: Int) => { 1 / 0; ()}
 
         support.invokeWatchHandler(arg1, arg2, handler) should be (None)
       }
@@ -432,7 +432,7 @@ class FunctionSupportSpec extends FunSpec with Matchers with MockitoSugar {
         val arg1 = JsNumber(1)
         val arg2 = JsNumber(2)
         var executed = false
-        val handler = (old: String, noo: String) => executed = true
+        val handler = (old: Option[String], noo: String) => executed = true
 
         support.invokeWatchHandler(arg1, arg2, handler) should be (None)
         executed should be(false)

--- a/notebooks/examples/urth-scala-widgets.ipynb
+++ b/notebooks/examples/urth-scala-widgets.ipynb
@@ -405,6 +405,15 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Now we set up a watch handler for variable `x` on channel `b`. \n",
+    "\n",
+    "Note that the first argument is of type `Option`, since an `oldVal` may not be present."
+   ]
+  },
+  {
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
@@ -412,8 +421,8 @@
    },
    "outputs": [],
    "source": [
-    "val handler = (oldVal: String, newVal: String) => \n",
-    "    channel(\"b\").set(\"y\", s\"Hello from the kernel! old: $oldVal, new: $newVal\")"
+    "val handler = (oldVal: Option[String], newVal: String) => \n",
+    "    channel(\"b\").set(\"y\", s\"Hello from the kernel! old: ${oldVal.getOrElse(\"\")}, new: $newVal\")"
    ]
   },
   {
@@ -481,8 +490,8 @@
    },
    "outputs": [],
    "source": [
-    "val handler = (oldVal: Seq[Int], newVal: Seq[Int]) => \n",
-    "    channel(\"c\").set(\"y\", s\"Hello from the kernel! old: $oldVal, new: $newVal\")"
+    "val handler = (oldVal: Option[Seq[Int]], newVal: Seq[Int]) => \n",
+    "    channel(\"c\").set(\"y\", s\"Hello from the kernel! old: ${oldVal.getOrElse(None)}, new: $newVal\")"
    ]
   },
   {


### PR DESCRIPTION
Fixes #128 

Allows `old_val` to be missing when parsing `change` messages. Adjusted watch handlers to take an `Option` type for the `oldVal` argument to allow for a missing `oldVal`.

To test:
- run the `Channels API` section of the `urth-scala-widgets` notebook
  - no console errors should appear when `.set(...)` is run
  - watch handlers should work for the initial `.set(...)` (create the watch handler before setting the variable on the channel)
