### PR TITLE
Explicit add dependency to spark

### DIFF
--- a/kernel-scala/build.sbt
+++ b/kernel-scala/build.sbt
@@ -10,7 +10,11 @@ scalaVersion := "2.10.4"
 
 val kernelVersion = "0.1.5-SNAPSHOT"
 
+val sparkVersion = "1.5.1"
+
 libraryDependencies ++= Seq(
+  "org.apache.spark" %% "spark-core" % sparkVersion  % "provided",
+  "org.apache.spark" %% "spark-repl" % sparkVersion  % "provided",
   "com.ibm.spark" %% "kernel" % kernelVersion % "provided",
   "com.ibm.spark" %% "kernel-api" % kernelVersion % "provided",
   "com.ibm.spark" %% "protocol" % kernelVersion % "provided",


### PR DESCRIPTION
I noticed that when we made change to https://github.com/ibm-et/spark-kernel to build assembly and not bundle Spark dependencies, then building the kernel-scala support woul fail due to missing Spark libs. I seems we were missing explicitly depending on Spark in our build.sbt. 

Although the docker images are not updated to have the latest SparkKernel, this changes do not cause any ill effect.
