### PR TITLE
Add/fix serializers for pandas types

### DIFF
--- a/kernel-python/urth/util/serializers.py
+++ b/kernel-python/urth/util/serializers.py
@@ -29,7 +29,6 @@ else:
 
 
 class PandasSeriesSerializer(BaseSerializer):
-    """A serializer for pandas.Series"""
     @staticmethod
     def klass():
         import pandas
@@ -39,7 +38,8 @@ class PandasSeriesSerializer(BaseSerializer):
     def serialize(obj, **kwargs):
         # Default to index orientation
         # {index -> {column -> value}}
-        return json.loads(obj.to_json(orient='index'))
+        date_format = kwargs.get('date_format', 'iso')
+        return json.loads(obj.to_json(orient='index', date_format=date_format))
 
     @staticmethod
     def check_packages():
@@ -62,7 +62,8 @@ class PandasDataFrameSerializer(BaseSerializer):
         limit = kwargs.get('limit', 100)
         # Default to split orientation 
         # {index -> [index], columns -> [columns], data -> [values]}
-        return json.loads(obj[:limit].to_json(orient='split'))
+        date_format = kwargs.get('date_format', 'iso')
+        return json.loads(obj[:limit].to_json(orient='split', date_format=date_format))
 
     @staticmethod
     def check_packages():

--- a/notebooks/examples/urth-core-function.ipynb
+++ b/notebooks/examples/urth-core-function.ipynb
@@ -276,7 +276,7 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
-    "collapsed": true
+    "collapsed": false
    },
    "outputs": [],
    "source": [
@@ -311,7 +311,7 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
-    "collapsed": true
+    "collapsed": false
    },
    "outputs": [],
    "source": [
@@ -364,7 +364,7 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
-    "collapsed": true
+    "collapsed": false
    },
    "outputs": [],
    "source": [
@@ -382,7 +382,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "### Example 5c: Function returning a pandas DataFrame"
+    "### Example 5c: Function returning a pandas Series"
    ]
   },
   {
@@ -395,27 +395,75 @@
    "source": [
     "import pandas as pd\n",
     "import numpy as np\n",
-    "def aDataFrameFunction(rows, cols):  \n",
-    "    data = [np.arange(0, int(cols), 1) for x in range(int(rows))]\n",
-    "    df = pd.DataFrame(data)\n",
-    "    return df"
+    "import string\n",
+    "\n",
+    "def aPandasSeriesFunction(n):\n",
+    "    data = np.random.randn(n)\n",
+    "    index = [c for c in string.ascii_lowercase[:n]]\n",
+    "    return pd.Series(data=data, index=index)\n",
+    "\n",
+    "aPandasSeriesFunction(3)"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
-    "collapsed": true
+    "collapsed": false
    },
    "outputs": [],
    "source": [
     "%%html\n",
     "<template is=\"dom-bind\">\n",
-    "    <urth-core-function id=\"f5c\" ref=\"aDataFrameFunction\" arg-rows=\"{{rows}}\" arg-cols=\"{{cols}}\" result=\"{{df}}\"></urth-core-function>\n",
+    "    <urth-core-function id=\"f5c\" ref=\"aPandasSeriesFunction\" arg-n=\"{{n}}\" result=\"{{s}}\"></urth-core-function>\n",
+    "    \n",
+    "    n<paper-slider min=\"1\" max=\"3\" step=\"1\" value=\"{{n}}\"></paper-slider>\n",
+    "    <button onClick=\"f5c.invoke()\">invoke</button>\n",
+    "    \n",
+    "    <p>a: <span>{{s.a}}</span></p>\n",
+    "    <p>b: <span>{{s.b}}</span></p>\n",
+    "    <p>c: <span>{{s.c}}</span></p>\n",
+    "</template>"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Example 5d: Function returning a pandas DataFrame"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "import pandas as pd\n",
+    "import numpy as np\n",
+    "\n",
+    "def aDataFrameFunction(rows, cols):  \n",
+    "    data = [np.arange(0, int(cols), 1) for x in range(int(rows))]\n",
+    "    return pd.DataFrame(data)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "%%html\n",
+    "<template is=\"dom-bind\">\n",
+    "    <urth-core-function id=\"f5d\" ref=\"aDataFrameFunction\" arg-rows=\"{{rows}}\" arg-cols=\"{{cols}}\" result=\"{{df}}\"></urth-core-function>\n",
     "    \n",
     "    rows<paper-slider min=\"1\" max=\"10\" step=\"1\" value=\"{{rows}}\"></paper-slider>\n",
     "    cols<paper-slider min=\"1\" max=\"10\" step=\"1\" value=\"{{cols}}\"></paper-slider>\n",
-    "    <button onClick=\"f5c.invoke()\">invoke</button>\n",
+    "    <button onClick=\"f5d.invoke()\">invoke</button>\n",
     "    \n",
     "    <p>columns: <span>{{df.columns}}</span></p>\n",
     "    <p>index: <span>{{df.index}}</span></p>\n",
@@ -427,7 +475,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "### Example 5d: Function returning a Spark Dataframe"
+    "### Example 5e: Function returning a Spark Dataframe"
    ]
   },
   {
@@ -461,17 +509,17 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
-    "collapsed": true
+    "collapsed": false
    },
    "outputs": [],
    "source": [
     "%%html\n",
     "<template is=\"dom-bind\">\n",
-    "    <urth-core-function id=\"f5d\" ref=\"aSparkDataFrameFunction\" limit=\"3\" arg-rows=\"{{rows}}\" arg-cols=\"{{cols}}\" result=\"{{df}}\"></urth-core-function>\n",
+    "    <urth-core-function id=\"f5e\" ref=\"aSparkDataFrameFunction\" limit=\"3\" arg-rows=\"{{rows}}\" arg-cols=\"{{cols}}\" result=\"{{df}}\"></urth-core-function>\n",
     "    \n",
     "    rows<paper-slider min=\"1\" max=\"10\" step=\"1\" value=\"{{rows}}\"></paper-slider>\n",
     "    cols<paper-slider min=\"1\" max=\"10\" step=\"1\" value=\"{{cols}}\"></paper-slider>\n",
-    "    <button onClick=\"f5d.invoke()\">invoke</button>\n",
+    "    <button onClick=\"f5e.invoke()\">invoke</button>\n",
     "    \n",
     "    <p>columns: <span>{{df.columns}}</span></p>\n",
     "    <p>index: <span>{{df.index}}</span></p>\n",
@@ -483,7 +531,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "### Example 5e: Function returning a custom class. Defining a custom serializer\n",
+    "### Example 5f: Function returning a custom class. Defining a custom serializer\n",
     "\n",
     "In this example, we have a function that returns a custom type `Foo`. We would like to serialize the `Foo` that's returned so that the value is useful for other widgets."
    ]
@@ -567,15 +615,175 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
-    "collapsed": true
+    "collapsed": false
    },
    "outputs": [],
    "source": [
     "%%html\n",
     "<template is=\"dom-bind\">\n",
-    "    <urth-core-function id=\"f5e\" ref=\"aFooFunction\" result=\"{{r}}\"></urth-core-function>\n",
-    "    <button onClick=\"f5e.invoke()\">invoke</button>    \n",
+    "    <urth-core-function id=\"f5f\" ref=\"aFooFunction\" result=\"{{r}}\"></urth-core-function>\n",
+    "    <button onClick=\"f5f.invoke()\">invoke</button>    \n",
     "    <span>{{r}}</span>\n",
+    "</template>"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Example 5g: Function returning an object consisting of non-serializeable types\n",
+    "\n",
+    "If you invoke a function that returns a Python object, then the object must be JSON serializable, which means that the object and it attributes or items must be reduced to basic Python types such as list, dict, int, float, str, etc.  The function below returns a dict whose item values are _not_ JSON serializable."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "import pandas as pd\n",
+    "from pandas.tslib import NaT\n",
+    "import numpy as np\n",
+    "from datetime import datetime, date\n",
+    "\n",
+    "def nonSerializeableTypes():\n",
+    "    return dict(\n",
+    "        nat=NaT,\n",
+    "        ndarray=np.linspace(0, 1, 5),\n",
+    "        npscalar=np.int64(1),\n",
+    "        date=date(2015,12,8),\n",
+    "        datetime=datetime.now()\n",
+    "    )"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "ns_types = nonSerializeableTypes()\n",
+    "ns_types"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "[type(v) for k,v in ns_types.items()]"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Attempting to invoke this function from a widget will result in a serialization error."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "%%html\n",
+    "<template is=\"dom-bind\">\n",
+    "    <urth-core-function id=\"f5g\" ref=\"nonSerializeableTypes\" result=\"{{d}}\"></urth-core-function>\n",
+    "    <button onClick=\"f5g.invoke()\">invoke</button>    \n",
+    "    <span>{{d}}</span>\n",
+    "</template>"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "To pass this object to and from widgets, you must convert the non-serializable object types to basic Python types.  The method of conversion will depend on the object.  For example, you can convert python `date` and `datetime` objects to their string representations using the built-in `str` function, or the `datetime.strftime` function if you want to pass dates in a specific format.  Numpy provides functions to convert numpy `ndarray` and scalar objects to Python types.\n",
+    "\n",
+    "The `make_serializable` function below handles conversion of all of the above non-serializable object types to python objects."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "def make_serializable(obj):\n",
+    "    if isinstance(obj, dict):\n",
+    "        return {k:make_serializable(v) for k,v in obj.items()}\n",
+    "    elif isinstance(obj, np.ndarray):\n",
+    "        return obj.tolist()\n",
+    "    elif isinstance(obj, np.generic):\n",
+    "        return np.asscalar(obj)\n",
+    "    elif isinstance(obj, date) or isinstance(obj, datetime):\n",
+    "        return str(obj)\n",
+    "    return obj\n",
+    "\n",
+    "def serializableTypes():\n",
+    "    return make_serializable(nonSerializeableTypes())"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "s_types = serializableTypes()\n",
+    "s_types"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "[type(v) for k,v in s_types.items()]"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Now you can invoke the `serializableTypes` function from a widget."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "%%html\n",
+    "<template is=\"dom-bind\">\n",
+    "    <urth-core-function id=\"f5gs\" ref=\"serializableTypes\" result=\"{{d}}\"></urth-core-function>\n",
+    "    <button onClick=\"f5gs.invoke()\">invoke</button>    \n",
+    "    <p>date: <span>{{d.date}}</span></p>\n",
+    "    <p>datetime: <span>{{d.datetime}}</span></p>\n",
+    "    <p>nat: <span>{{d.nat}}</span></p>\n",
+    "    <p>ndarray: <span>{{d.ndarray}}</span></p>\n",
+    "    <p>npscalar: <span>{{d.npscalar}}</span></p>\n",
     "</template>"
    ]
   },


### PR DESCRIPTION
Add pandas Series serializer.

Switch to using `to_json` method for serializing pandas DataFrames.  Converts
dates and timestamps to integers.

Fixes #138 
