### PR TITLE
Fix doc generation and build process.

### DIFF
--- a/etc/docs/site/elements/urth-docs-panel/urth-docs-panel.html
+++ b/etc/docs/site/elements/urth-docs-panel/urth-docs-panel.html
@@ -117,7 +117,7 @@
                         <a class="top-nav-item" href$="[[repositoryUrl]]">Repository</a>
                     </template>
                 </paper-toolbar>
-                <iron-component-page _catalog active="{{activeDescriptor}}" doc-elements="{{elementDescriptors}}"
+                <iron-component-page catalog active="{{activeDescriptor}}" doc-elements="{{elementDescriptors}}"
                         doc-behaviors="{{behaviorDescriptors}}" doc-src="[[docSrc]]">
                 </iron-component-page>
             </paper-header-panel>

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -8,10 +8,16 @@ var gulp = require('gulp'),
 
 gulp.task('watch', function () {
     watch(['elements/**/*',
-           'etc/docs/**/*',
            'kernel-python/**/*',
            'kernel-scala/**/*',
            'nb-extension/**/*'], function(){
         run('make dist').exec();
+    });
+});
+
+gulp.task('watch-docs', function () {
+    watch(['elements/**/*',
+           'etc/docs/**/*'], function(){
+        run('make dist/docs').exec();
     });
 });

--- a/package.json
+++ b/package.json
@@ -28,7 +28,8 @@
     "test": "wct elements/*/test",
     "test-sauce": "wct --skip-plugin local --plugin sauce elements/*/test",
     "system-test": "node_modules/mocha/bin/mocha system-test/*-specs.js --timeout 30000 --reporter spec",
-    "watch": "gulp watch"
+    "watch": "gulp watch",
+    "watch-docs": "gulp watch-docs"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
- Updated the usage of `iron-component-page` to use `catalog` instead of `_catalog` attribute.
- Modified build of docs to use its own watch process independent of development watch.
- Added `make dist/docs` to the `all` target.

Related to issue #112 though I was not able to reproduce the error that was seen in that issue.
