### PR TITLE
proper height for tables in dashboard upon resize, remove black border

### DIFF
--- a/elements/urth-viz-table/urth-viz-table.html
+++ b/elements/urth-viz-table/urth-viz-table.html
@@ -29,6 +29,7 @@ The table accepts data via attribute `datarows` and column headers via attribute
         #tableContainer {
             overflow: scroll;
             border-spacing: 0;
+            border: 0;
             display: block;
         }
 
@@ -37,7 +38,7 @@ The table accepts data via attribute `datarows` and column headers via attribute
         }
         </style>
 
-        <table id="tableContainer" style="width:100%; height:100%;"></table>
+        <table id="tableContainer" style="width:100%; height:auto;"></table>
         <content></content>
     </template>
     <script>


### PR DESCRIPTION
@aluu317 @lbustelo 

Should fix #152. #153 was fixed by a patch to our handsontable fork.  You should be able to close that as well.
