### PR TITLE
Fixed when parameters set to 0 or false

### DIFF
--- a/elements/urth-core-function/test/urth-core-function.html
+++ b/elements/urth-core-function/test/urth-core-function.html
@@ -506,7 +506,7 @@
                 var fElmt = fixture('basic');
                 sinon.stub(fElmt, "_tryInvoke");
 
-                fElmt.args.x = NaN
+                fElmt.args.x = NaN;
 
                 fElmt._onSignatureChange({
                     x: {'value': 5}
@@ -519,6 +519,28 @@
                 expect(fElmt.hasOwnProperty('argX')).to.be.true;
 
                 expect(fElmt.argX).to.equal(5);
+            });
+
+            it('should set to values on property when they are either 0 or false', function() {
+                var fElmt = fixture('basic');
+                sinon.stub(fElmt, "_tryInvoke");
+
+                fElmt.argX = 0;
+                fElmt.argY = false;
+
+                fElmt._onSignatureChange({
+                    x: {'required': true},
+                    y: {'required': true},
+                    z: {}
+                });
+
+                expect(fElmt.args).to.eql({x: 0, y: false});
+
+                expect(fElmt.hasOwnProperty('argX')).to.be.true;
+                expect(fElmt.hasOwnProperty('argY')).to.be.true;
+
+                expect(fElmt.argX).to.equal(0);
+                expect(fElmt.argY).to.be.false;
             });
 
             it('should try to invoke the function if auto is set', function() {

--- a/elements/urth-core-function/urth-core-function.html
+++ b/elements/urth-core-function/urth-core-function.html
@@ -397,7 +397,7 @@ Both examples are equivalent to invoking `aFunction(x=5, y=4)`
                             notify: true,
                             reflectToAttribute: true,
                             observer: argPropObserverName,
-                            value: this[argPropName] || sig[param].value
+                            value: this[argPropName] !== undefined ? this[argPropName] : sig[param].value
                         }
 
                     }.bind(this));


### PR DESCRIPTION
While doing the Todo tutorial, found a case where the urth-core-function wasn't getting correctly configured when the parameter value was set to `0`. The template below shows an example.

```
<template is="dom-repeat" items="{{todo}}">
            <li>
                <urth-core-function ref="removeTodo" arg-idx="[[index]]" onClick="this.invoke()">
                    <button>x</button> 
                </urth-core-function>  
                {{item.0}}
            </li>
        </template>
```

All but the first item were working. That was do to `index` equal to `0`. This PR fixes that case.
