### PR TITLE
Fixes problem with channel created too late

### DIFF
--- a/elements/urth-core-bind/urth-core-bind.html
+++ b/elements/urth-core-bind/urth-core-bind.html
@@ -46,12 +46,13 @@
             properties: {
                 channel: {
                     type: String,
+                    value: 'default',
                     observer: '_onChannelChange'
                 }
             },
             behaviors: [Urth.DomBindBehavior],
 
-            attached: function() {
+            created: function() {
                 this._createChannel();
             },
 

--- a/notebooks/examples/urth-core-bind.ipynb
+++ b/notebooks/examples/urth-core-bind.ipynb
@@ -182,7 +182,7 @@
    "outputs": [],
    "source": [
     "%%html\n",
-    "<template is='urth-core-bind' channel=\"{{channel}}\">\n",
+    "<template is='urth-core-bind' channel$=\"{{channel}}\">\n",
     "    <div>Hello <span>{{user}}</span></div>\n",
     "    Name: <input value='{{user::input}}'></input>\n",
     "    Channel: <select value='{{channel::input}}'>\n",


### PR DESCRIPTION
When running the Todo tutorial, noticed a cell that stop working after merging PR #179. The cell looks like this

``` html
%%HTML
<template is="urth-core-bind">
    <urth-core-function id="addTodo" ref="addTodo" arg-title="{{title}}" arg-date="{{dueDate}}"></urth-core-function>  
    <br/>Add New Item
    <form onSubmit="return false;">
        title: <input id="titleIn" type="text" value="{{title::change}}"></input> 
        date: <input id="dateIn" type="text" value="{{dueDate::change}}"></input> 
        <button onClick="addTodo.invoke(); titleIn.value=''; dateIn.value=''">Add</button>
    </form>
</template>
```

Nothing special, but the following error was coming from `urth-core-bind`

![screen shot 2016-01-20 at 11 37 20 am](https://cloud.githubusercontent.com/assets/2474841/12457462/363179ea-bf6a-11e5-83fc-0aa094b75120.png)

The problem was that property changes were arriving before the 'urth-core-channel' gets created. `attached` is to late in the lifecycle, and placing a protection check in `_propertyChanged` would cause the channel to loose values. I moved the creation of the `urth-core-channel` to `created` and fixed that particular issue. 

I tested the relevant notebooks and all seems to be working fine. Still, I remember @deedubbu mentioning something about moving the create of the channel to `attached` for some reason I don't recall.

/cc @deedubbu 
