### PR TITLE
Run tests on multiple browsers

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,9 @@
+env:
+  global:
+    - DISPLAY=:99.0
+    - BASEURL=http://localhost:9500
+    - BROWSER_LIST="chrome firefox"
+
 sudo: required
 
 language: c
@@ -13,11 +19,10 @@ addons:
 before_script:
   - curl -sL https://deb.nodesource.com/setup_4.x | sudo -E bash -
   - sudo apt-get install -y nodejs
-  - export DISPLAY=:99.0
   - sh -e /etc/init.d/xvfb start
 
 script:
-  - BASEURL=http://127.0.0.1:9500 make all
+  - make all
 
 deploy:
   skip_cleanup: true

--- a/wct.conf.js
+++ b/wct.conf.js
@@ -11,19 +11,16 @@ module.exports = {
       disabled: true,
       browsers: [
           {
-              browserName: "chrome",
-              platform: "Linux",
-              version: "45.0"
+              browserName: "firefox",
+              platform: "Linux"
+          },
+          {
+              browserName: "safari",
+              platform: "OS X 10.10"
           },
           {
               browserName: "chrome",
-              platform: "OS X 10.10",
-              version: "45.0"
-          },
-          {
-              browserName: "chrome",
-              platform: "Windows 10",
-              version: "45.0"
+              platform: "Windows 10"
           }
       ]
     }


### PR DESCRIPTION
Use `$(foreach)` in the run-test makefile rule to drive system tests using the `BROWSER_LIST` environment variable instead of the travis matrix, which runs the entire build multiple times.  Also, modify the wct.conf.js array to use different browsers on different platforms for sauce unit tests.
