### PR TITLE
Switch to main handsontable repository

### DIFF
--- a/elements/urth-viz-table/bower.json
+++ b/elements/urth-viz-table/bower.json
@@ -19,7 +19,7 @@
     "tests"
   ],
   "dependencies": {
-    "handsontable": "ibm-et/handsontable#0.20.2-ibm",
+    "handsontable": "handsontable/handsontable#^0.22",
     "polymer": "Polymer/polymer#^1.2.4",
     "requirejs": "^2.1.0"
   },

--- a/elements/urth-viz-table/urth-viz-table.html
+++ b/elements/urth-viz-table/urth-viz-table.html
@@ -36,6 +36,14 @@ The table accepts data via attribute `datarows` and column headers via attribute
         .handsontable td {
             white-space: normal;
         }
+
+        .handsontable .manualColumnResizer,
+        .handsontable .manualRowResizer,
+        .ht_clone_top, .ht_clone_left,
+        .ht_clone_top_left_corner, .ht_clone_bottom_left_corner,
+        .ht_clone_debug {
+            z-index: inherit;
+        }
         </style>
 
         <table id="tableContainer" style="width:100%; height:auto;"></table>


### PR DESCRIPTION
The fixes on the ibm-et fork have been merged to 0.22.0, so we can go back to the main line

I noticed a regression #208 which seems to have occurred prior to this branch, so we'll work on that separately

(c) Copyright IBM Corp. 2016
