### PR TITLE
Delay urth-core-bind render till dependencies loaded.

### DIFF
--- a/elements/urth-core-bind/bower.json
+++ b/elements/urth-core-bind/bower.json
@@ -19,8 +19,9 @@
     "tests"
   ],
   "dependencies": {
+    "polymer": "Polymer/polymer#^1.2.4",
     "iron-ajax": "PolymerElements/iron-ajax#^1.0.4",
-    "polymer": "Polymer/polymer#^1.2.4"
+    "promise-polyfill": "polymerlabs/promise-polyfill#^1.0.0"
   },
   "private": true
 }

--- a/elements/urth-core-bind/dom-bind-behavior.html
+++ b/elements/urth-core-bind/dom-bind-behavior.html
@@ -16,6 +16,7 @@
  subject to an additional IP rights grant found at http://polymer.github.io/PATENTS.txt
 -->
 <link rel="import" href="../polymer/polymer.html">
+<link rel="import" href="../promise-polyfill/promise-polyfill-lite.html">
 
 <script>
     'use strict';
@@ -110,20 +111,33 @@
          * necessary to call if HTMLImports with the async attribute are used.
          */
         render: function() {
-            this._ensureReady();
-            if (!this._children) {
-                this._template = this;
-                this._prepAnnotations();
-                this._prepEffects();
-                this._prepBehaviors();
-                this._prepConfigure();
-                this._prepBindings();
-                this._prepPropertyInfo();
-                Polymer.Base._initFeatures.call(this);
-                this._children = Polymer.TreeApi.arrayCopyChildNodes(this.root);
-            }
-            this._insertChildren();
-            this.fire('dom-change');
+            this._customRender().then(function() {
+                this._ensureReady();
+                if (!this._children) {
+                    this._template = this;
+                    this._prepAnnotations();
+                    this._prepEffects();
+                    this._prepBehaviors();
+                    this._prepConfigure();
+                    this._prepBindings();
+                    this._prepPropertyInfo();
+                    Polymer.Base._initFeatures.call(this);
+                    this._children = Polymer.TreeApi.arrayCopyChildNodes(this.root);
+                }
+
+                this._insertChildren();
+                this.fire('dom-change');
+            }.bind(this));
+        },
+
+        // BEGIN URTH_CUSTOM
+        /**
+         * Method which can be overridden by elements implementing this behavior
+         * to customize the render process.
+         */
+        _customRender: function() {
+            return Promise.resolve(true);
         }
+        // END URTH_CUSTOM
     };
 </script>

--- a/elements/urth-core-bind/test/urth-core-bind.html
+++ b/elements/urth-core-bind/test/urth-core-bind.html
@@ -169,9 +169,38 @@
             it('should use proper channel data', function() {
                 parentBind.user = 'foo';
                 childBind.user = 'bar';
-                console.log(parentUser.textContent);
                 expect(parentUser.textContent).to.equal('foo');
                 expect(childUser.textContent).to.equal('bar');
+            });
+        });
+
+        describe('_customRender', function() {
+            it('should get invoked when the element is attached', function() {
+                var renderTemplate = new window.Urth['urth-core-bind']();
+                var renderSpy = sinon.spy(renderTemplate, '_customRender');
+                document.body.appendChild(renderTemplate);
+                renderSpy.restore();
+                expect(renderSpy).to.have.been.calledOnce;
+            });
+
+            it('should retrieve the pending imports', function() {
+                var importBroker = window.Urth['urth-core-import-broker'].getImportBroker();
+                var importSpy = sinon.spy(importBroker, 'getPendingImports');
+                var renderTemplate = new window.Urth['urth-core-bind']();
+                renderTemplate._customRender();
+                importSpy.restore();
+                expect(importSpy).to.have.been.calledOnce;
+            });
+
+            it('should not retrieve the pending imports if "no-wait" is specified', function() {
+                debugger;
+                var importBroker = window.Urth['urth-core-import-broker'].getImportBroker();
+                var importSpy = sinon.spy(importBroker, 'getPendingImports');
+                var renderTemplate = new window.Urth['urth-core-bind']();
+                renderTemplate.setAttribute('no-wait', true);
+                renderTemplate._customRender();
+                importSpy.restore();
+                expect(importSpy).to.have.not.been.called;
             });
         });
     </script>

--- a/elements/urth-core-bind/urth-core-bind.html
+++ b/elements/urth-core-bind/urth-core-bind.html
@@ -3,8 +3,10 @@
 # Distributed under the terms of the Modified BSD License.
 -->
 <link rel="import" href="../polymer/polymer.html">
+<link rel="import" href="../promise-polyfill/promise-polyfill-lite.html">
 <link rel="import" href="./dom-bind-behavior.html">
 <link rel="import" href="../urth-core-channel/urth-core-channel.html">
+<link rel="import" href="../urth-core-import/urth-core-import-broker.html">
 
 <!--
  Provides a mechanism to enable [Polymer binding](https://www.polymer-project.org/1.0/docs/devguide/data-binding.html)
@@ -24,6 +26,18 @@
  </template>
  ```
 
+ By default, `urth-core-bind` will wait to render the template until all
+ preceding `urth-core-import` dependencies have completed. Set the `no-wait`
+ attribute on the element to ignore dependencies and render immediately.
+
+ Example: _Do not wait for dependencies to load before rendering._
+
+ ```html
+ <template is='urth-core-bind' no-wait>
+     <div>Hello <span>{{user}}</span></div>
+ </template>
+ ```
+
  @group Urth Core
  @element urth-core-bind
  -->
@@ -31,6 +45,8 @@
     <script>
     (function() {
         'use strict';
+
+        var importBroker = Urth['urth-core-import-broker'].getImportBroker();
 
         window.Urth = window.Urth || {};
 
@@ -44,6 +60,15 @@
             is: 'urth-core-bind',
             extends: 'template',
             properties: {
+                /**
+                 * Determines whether to wait for dependencies to load before
+                 * rendering. Set to `true` to render immediately and not wait.
+                 */
+                noWait: {
+                    type: Boolean,
+                    value: false,
+                    reflectToAttribute: true
+                },
                 /**
                  * The name of the channel to use for data binding.
                  */
@@ -71,6 +96,27 @@
                 }
             },
 
+            /**
+             * Invoked by DomBindBehavior on `attached`. Used to delay rendering
+             * until after dependencies have loaded if `noWait` is not
+             * true.
+             */
+            _customRender: function() {
+                // Have to use `hasAttribute` here because at the time this
+                // method is invoked, the properties for the element have not
+                // been initialized (so can't check this.noWait). Since
+                // `no-wait` is a boolean property, just check for its
+                // existance (any value is assumed `true`).
+                if (!this.hasAttribute('no-wait')) {
+                    var pendingImports = importBroker.getPendingImports().map(function(key) {
+                        return key.completed;
+                    });
+                    return Promise.all(pendingImports);
+                } else {
+                    return Promise.resolve(true);
+                }
+            },
+
             _onChannelChange: function(newVal, oldVal) {
                 if (!this.channelElement) {
                     this._createChannel();
@@ -82,7 +128,8 @@
             _propertyChanged: function(property, newVal, oldVal) {
                 // Only set the update on the channel if it is an actual
                 // value change. Channel change is handled separately.
-                if (newVal !== oldVal && property !== 'channel') {
+                if (newVal !== oldVal && property !== 'channel' &&
+                        property !== 'noWait') {
                     this.channelElement.set(property, newVal);
                 }
             }

--- a/elements/urth-core-channel/urth-core-channel.html
+++ b/elements/urth-core-channel/urth-core-channel.html
@@ -110,7 +110,7 @@ dataChannel.set('user', 'Luke');
             },
 
             created: function() {
-                this._broker = new Urth['urth-core-channel-broker'].getChannelBroker();
+                this._broker = Urth['urth-core-channel-broker'].getChannelBroker();
             },
 
             detached: function() {

--- a/elements/urth-core-import/bower.json
+++ b/elements/urth-core-import/bower.json
@@ -20,7 +20,8 @@
   ],
   "dependencies": {
     "polymer": "Polymer/polymer#^1.2.4",
-    "iron-ajax": "PolymerElements/iron-ajax#^1.0.4"
+    "iron-ajax": "PolymerElements/iron-ajax#^1.0.4",
+    "promise-polyfill": "polymerlabs/promise-polyfill#^1.0.0"
   },
   "private": true
 }

--- a/elements/urth-core-import/test/urth-core-import-broker.html
+++ b/elements/urth-core-import/test/urth-core-import-broker.html
@@ -1,0 +1,181 @@
+<!doctype html>
+<!--
+# Copyright (c) Jupyter Development Team.
+# Distributed under the terms of the Modified BSD License.
+-->
+<html>
+<head>
+    <meta charset="utf-8">
+    <!-- STEP 1: Provide a title for the test suite. -->
+    <title>urth-core-import-broker tests</title>
+    <meta name='viewport' content='width=device-width, minimum-scale=1.0, initial-scale=1.0, user-scalable=yes'>
+
+    <!-- Need the web component polyfill for browsers without native support. -->
+    <script src='../../webcomponentsjs/webcomponents-lite.js'></script>
+
+    <!-- Load test framework and helpers. -->
+    <script src='../../web-component-tester/browser.js'></script>
+    <script src='../../test-fixture/test-fixture-mocha.js'></script>
+    <link rel='import' href='../../test-fixture/test-fixture.html'>
+
+    <!-- STEP 2: Import the element to test. -->
+    <link rel='import' href='../urth-core-import-broker.html'>
+</head>
+
+<body>
+    <!-- STEP 3: Setup document with DOM to test. Use test-fixture elements
+         to ease setup and cleanup of elements. -->
+    <test-fixture id='basic'>
+        <template>
+            <urth-core-import-broker id='basicBroker'></urth-core-import-broker>
+        </template>
+    </test-fixture>
+
+    <div id='mockImport'></div>
+
+    <div id='completedImport'></div>
+
+    <script>
+        // STEP 4: Define any globals needed by the test suite.
+        var basicBroker;
+        var mockImport = document.getElementById('mockImport');
+        var completedImport = document.getElementById('completedImport');
+
+        beforeEach(function() {
+            basicBroker = fixture('basic');
+        });
+
+        // STEP 5: Define suite(s) and tests.
+        describe('addImport', function() {
+            it('should return null if element not specified', function() {
+                var rtn = basicBroker.addImport(null, '/my/url', 'mypackage');
+
+                expect(rtn).to.be.null;
+            });
+
+            it('should return null if href not specified', function() {
+                var rtn = basicBroker.addImport(mockImport, null, 'mypackage');
+
+                expect(rtn).to.be.null;
+            });
+
+            it('should return an object with fields set based on specified inputs', function() {
+                var rtn = basicBroker.addImport(mockImport, '/my/url', 'mypackage');
+
+                expect(rtn).to.not.be.null;
+                expect(rtn.href).to.equal('/my/url');
+                expect(rtn.packageRef).to.equal('mypackage');
+            });
+
+            it('should mark the return object completed and successfull when the import loads', function(done) {
+                var rtn = basicBroker.addImport(mockImport, '/my/url', 'mypackage');
+
+                expect(rtn).to.not.be.null;
+                expect(rtn.href).to.equal('/my/url');
+                expect(rtn.packageRef).to.equal('mypackage');
+
+                rtn.completed.then(function() {
+                    rtn.result.then(function() {
+                        done();
+                    });
+                }).catch(function() {
+                    expect.fail();
+                    done();
+                });
+
+                Polymer.Base.fire('load', null, {node: mockImport});
+            });
+
+            it('should mark the return object completed and unsuccessfull when the import errors', function(done) {
+                var rtn = basicBroker.addImport(mockImport, '/my/url', 'mypackage');
+
+                expect(rtn).to.not.be.null;
+                expect(rtn.href).to.equal('/my/url');
+                expect(rtn.packageRef).to.equal('mypackage');
+
+                rtn.completed.then(function() {
+                    rtn.result.then(function() {
+                        expect.fail();
+                        done();
+                    }, function() {
+                        // Expectation is the result is a failure.
+                        done();
+                    });
+                }, function() {
+                    expect.fail();
+                    done();
+                });
+
+                Polymer.Base.fire('importerror', null, {node: mockImport});
+            });
+        });
+
+        describe('getPendingImports', function() {
+            it('should return an empty array if there are no pending imports', function() {
+                var pending = basicBroker.getPendingImports();
+
+                expect(pending).to.be.instanceof(Array);
+                expect(pending).to.be.empty;
+            });
+
+            it('should return pending imports', function() {
+                basicBroker.addImport(mockImport, '/url/one', 'onepackage');
+                basicBroker.addImport(mockImport, '/url/two', 'twopackage');
+
+                var pending = basicBroker.getPendingImports();
+
+                expect(pending).to.be.instanceof(Array);
+                expect(pending).to.have.length(2);
+                expect(pending[0].href).to.equal('/url/one');
+                expect(pending[0].packageRef).to.equal('onepackage');
+                expect(pending[1].href).to.equal('/url/two', 'twopackage');
+                expect(pending[1].packageRef).to.equal('twopackage');
+            });
+
+            it('should not include imports that have already completed successfully', function() {
+                basicBroker.addImport(mockImport, '/url/one', 'onepackage');
+                basicBroker.addImport(completedImport, 'url/completed', 'completedpackage');
+                basicBroker.addImport(mockImport, '/url/two', 'twopackage');
+
+                Polymer.Base.fire('load', null, {node: completedImport});
+
+                var pending = basicBroker.getPendingImports();
+
+                expect(pending).to.be.instanceof(Array);
+                expect(pending).to.have.length(2);
+                expect(pending[0].href).to.equal('/url/one');
+                expect(pending[0].packageRef).to.equal('onepackage');
+                expect(pending[1].href).to.equal('/url/two', 'twopackage');
+                expect(pending[1].packageRef).to.equal('twopackage');
+            });
+
+            it('should not include imports that have already completed with error', function() {
+                basicBroker.addImport(mockImport, '/url/one', 'onepackage');
+                basicBroker.addImport(completedImport, 'url/completed', 'completedpackage');
+                basicBroker.addImport(mockImport, '/url/two', 'twopackage');
+
+                Polymer.Base.fire('importerror', null, {node: completedImport});
+
+                var pending = basicBroker.getPendingImports();
+
+                expect(pending).to.be.instanceof(Array);
+                expect(pending).to.have.length(2);
+                expect(pending[0].href).to.equal('/url/one');
+                expect(pending[0].packageRef).to.equal('onepackage');
+                expect(pending[1].href).to.equal('/url/two', 'twopackage');
+                expect(pending[1].packageRef).to.equal('twopackage');
+            });
+        });
+
+        describe('getImportBroker', function() {
+            it('should return a singleton instance of the import broker', function() {
+                var one = window.Urth['urth-core-import-broker'].getImportBroker();
+                var two = window.Urth['urth-core-import-broker'].getImportBroker();
+
+                expect(one).to.equal(two);
+            });
+        });
+
+    </script>
+</body>
+</html>

--- a/elements/urth-core-import/test/urth-core-import.html
+++ b/elements/urth-core-import/test/urth-core-import.html
@@ -7,7 +7,7 @@
 <head>
     <meta charset="utf-8">
     <!-- STEP 1: Provide a title for the test suite. -->
-    <title>urth-core-bind tests</title>
+    <title>urth-core-import tests</title>
     <meta name='viewport' content='width=device-width, minimum-scale=1.0, initial-scale=1.0, user-scalable=yes'>
 
     <!-- Need the web component polyfill for browsers without native support. -->
@@ -40,6 +40,20 @@
     <test-fixture id='validHref'>
         <template>
             <link rel='import' href='/elements/iron-ajax/iron-ajax.html'
+                    is='urth-core-import' package='PolymerElements/iron-ajax'>
+        </template>
+    </test-fixture>
+
+    <test-fixture id='loadingHref'>
+        <template>
+            <link rel='import' href='elements/iron-ajax/iron-ajax.html'
+                    is='urth-core-import' package='PolymerElements/iron-ajax'>
+        </template>
+    </test-fixture>
+
+    <test-fixture id='errorLoadHref'>
+        <template>
+            <link rel='import' href='elementsNo/iron-ajax/iron-ajax.html'
                     is='urth-core-import' package='PolymerElements/iron-ajax'>
         </template>
     </test-fixture>
@@ -107,10 +121,69 @@
                 var importSpy = sinon.spy(link, 'importHref');
 
                 link.addEventListener('importerror', function(event) {
+                    importSpy.restore();
                     expect(event.detail.msg).to.not.be.null;
                     expect(importSpy).to.be.calledOnce;
                     done();
                 });
+            });
+        });
+
+        describe('href', function() {
+            it('change should add the url to the pending imports', function() {
+                var dummyURL = '../../dummy/dummy.html';
+                var link = fixture('invalidHref');
+
+                var importBroker = window.Urth['urth-core-import-broker'].getImportBroker();
+                var addSpy = sinon.spy(importBroker, 'addImport');
+                link.href = dummyURL;
+
+                addSpy.restore();
+
+                expect(addSpy).to.be.calledOnce;
+                var addSpyArgs = addSpy.getCall(0).args;
+                expect(addSpyArgs[0]).to.equal(link);
+                expect(addSpyArgs[1]).to.equal(dummyURL);
+                expect(addSpyArgs[2]).to.equal(link.package);
+            });
+        });
+
+        describe('loading event', function() {
+            it('should fire when the element is attached and bubble to body', function(done) {
+                var handler = function(event) {
+                    document.body.removeEventListener('loading', handler);
+                    done();
+                };
+                document.body.addEventListener('loading', handler);
+                var link = fixture('validHref');
+            });
+        });
+
+        describe('finished event', function() {
+            it('should fire when the element has loaded and bubble to body', function(done) {
+                var handler = function(event) {
+                    if (event.detail && event.detail.href === link.getAttribute('href')) {
+                        document.body.removeEventListener('finished', handler);
+                        expect(event.detail.loaded).to.be.true;
+                        done();
+                    }
+                };
+                document.body.addEventListener('finished', handler);
+
+                var link = fixture('loadingHref');
+            });
+
+            it('should fire when the element has failed to load and bubble to body', function(done) {
+                var handler = function(event) {
+                    if (event.detail && event.detail.href === link.getAttribute('href')) {
+                        document.body.removeEventListener('finished', handler);
+                        expect(event.detail.loaded).to.be.false;
+                        done();
+                    }
+                };
+                document.body.addEventListener('finished', handler);
+
+                var link = fixture('errorLoadHref');
             });
         });
 

--- a/elements/urth-core-import/urth-core-import-broker.html
+++ b/elements/urth-core-import/urth-core-import-broker.html
@@ -1,0 +1,153 @@
+<!--
+# Copyright (c) Jupyter Development Team.
+# Distributed under the terms of the Modified BSD License.
+-->
+<link rel="import" href="../polymer/polymer.html">
+<link rel="import" href="../promise-polyfill/promise-polyfill-lite.html">
+<link rel="import" href="../urth-core-behaviors/jupyter-widget-behavior.html">
+<link rel="import" href="../urth-core-behaviors/jupyter-kernel-observer.html">
+<link rel="import" href="../urth-core-storage/urth-core-storage.html">
+
+<!--
+`urth-core-import-broker` is a singleton element that is used to
+keep track of pending imports and package downloads for `urth-core-import`
+elements. _This element is not intended for use as a standalone element._
+
+Example: _Retrieve the singleton instance._
+
+```javascript
+var broker = window.Urth['urth-core-import-broker'].getImportBroker();
+```
+
+@group Urth Core
+@element urth-core-import-broker
+-->
+<dom-module id='urth-core-import-broker'>
+    <script>
+    (function() {
+        'use strict';
+
+        // Initializes an import object that can be used to track the
+        // completion and result of the import process.
+        var initImport = function(href, packageRef, handler) {
+            return new function() {
+                // The requested url.
+                this.href = href;
+
+                // An option package reference.
+                this.packageRef = packageRef;
+
+                // Promise that indicates success or failure to import.
+                this.result = new Promise(handler);
+
+                // Promise that resolves with either success or failure of
+                // import.
+                this.completed = Promise.resolve({
+                    then: function(resolve) {
+                        this.result.then(function() {
+                            resolve();
+                        }, function() {
+                            resolve();
+                        });
+                    }.bind(this)
+                });
+            };
+        };
+
+        // Keeps track of the pending imports
+        var pendingImports = {};
+        var IMPORT_PROMISES = [];
+
+        var singleton;
+
+        window.Urth = window.Urth || {};
+
+        window.Urth['urth-core-import-broker'] = Polymer({
+            is: 'urth-core-import-broker',
+
+            /**
+             * Tracks the completion of an `urth-core-import` element.
+             *
+             * @method addImport
+             * @param {HTMLElement} importElement The `urth-core-import` element
+             * associated with the specified `href`.
+             * @param {String} href The requested resource url.
+             * @param {String} packageName The requested resources installable
+             * package name.
+             * @return {{completed: Promise, href: String, packageRef: String, result: Promise}}
+             */
+            addImport: function(importElement, href, packageName) {
+                var key = href + packageName;
+                if (!importElement || !href) {
+                    return null;
+                }
+
+                if (!pendingImports[key]) {
+                    var item = initImport(href, packageName, function(resolve, reject) {
+                        var resolver = function(event) {
+                            importElement.removeEventListener('load', resolver);
+
+                            Polymer.Base.fire('finished', {
+                                    href: importElement.getAttribute('href'),
+                                    package: packageName,
+                                    loaded: true
+                                }, {
+                                    node: importElement
+                                }
+                            );
+                            delete pendingImports[key];
+                            resolve();
+                        }
+                        var rejector = function(event) {
+                            importElement.removeEventListener('importerror', rejector);
+
+                            Polymer.Base.fire('finished', {
+                                    href: importElement.getAttribute('href'),
+                                    package: packageName,
+                                    loaded: false
+                                }, {
+                                    node: importElement
+                                }
+                            );
+                            delete pendingImports[key];
+                            reject();
+                        }
+                        importElement.addEventListener('load', resolver);
+                        importElement.addEventListener('importerror', rejector);
+                    });
+                    pendingImports[key] = item;
+                }
+
+                return pendingImports[key];
+            },
+
+            /**
+             * Returns an array of imports that are pending completion.
+             *
+             * @method getPendingImports
+             * @return {Array} The pending imports. Each item in the array is
+             * an object with the following properties:
+             * `{completed: Promise, href: String, packageRef: String, result: Promise}`
+             */
+            getPendingImports: function() {
+                // Convert the object into an array.
+                return Object.keys(pendingImports).map(function(key) {
+                    return pendingImports[key];
+                });
+            }
+        });
+
+        /**
+         * Retrieves the singleton instance of `urth-core-import-broker`.
+         *
+         * @method getChannelBroker
+         * @return {HTMLElement} The singleton `urth-core-import-broker` element.
+         */
+        Urth['urth-core-import-broker'].getImportBroker = function() {
+            if (!singleton) {
+                singleton = new Urth['urth-core-import-broker']();
+            }
+            return singleton;
+        }
+    })();
+</script>

--- a/elements/urth-core-import/urth-core-import.html
+++ b/elements/urth-core-import/urth-core-import.html
@@ -5,6 +5,7 @@
 <link rel='import' href='../polymer/polymer.html'>
 <link rel='import' href='../iron-ajax/iron-ajax.html'>
 <link rel='import' href='../urth-core-behaviors/jupyter-notebook-env.html'>
+<link rel='import' href='./urth-core-import-broker.html'>
 
 <!--
  Adds functionality to `<link>` to provide a mechanism to
@@ -37,19 +38,53 @@
 </dom-module>
 
 <script>
+(function() {
     'use strict';
     var loadedPackages = {},
-        logTag = 'urth-core-import: ';
+        LOG_TAG = 'urth-core-import: ',
+        importBroker = Urth['urth-core-import-broker'].getImportBroker();
 
-    Polymer({
+    window.Urth = window.Urth || {};
+
+    window.Urth['urth-core-import'] = Polymer({
         is: 'urth-core-import',
         extends: 'link',
         /**
          * fired if the specified package or href fails to load.
+         *
          * @event `importerror`
          */
 
+        /**
+         * fired if the specified package or href loads successfully.
+         *
+         * @event `load`
+         */
+
+        /**
+         * fired when the specified package or href begins loading.
+         *
+         * @event `loading`
+         */
+
+        /**
+         * fired when the specified package or href finishes loading. Listen
+         * to `load` and `error` and `importerror` events to determine success
+         * or failure of loading.
+         *
+         * @event `finished`
+         */
+
         properties: {
+            /**
+            * If `true`, console output will be written to indicate the
+            * progress of importing the specified `package`.
+            */
+            debug: {
+                type: Boolean,
+                value: false
+            },
+
             /**
              * The project dependency to load. Any endpoints that are
              * valid for the [`bower install`](http://bower.io/docs/api/#install)
@@ -59,14 +94,6 @@
                 type: String,
                 observer: '_packageChanged',
                 reflectToAttribute: true
-            },
-            /**
-             * If `true`, console output will be written to indicate the
-             * progress of importing the specified `package`.
-             */
-            debug: {
-                type: Boolean,
-                value: false
             },
 
             /**
@@ -89,20 +116,28 @@
             }
         },
 
+        attached: function() {
+            var href = this.getAttribute('href');
+            this.fire('loading', {
+                href: href,
+                package: this.package
+            });
+        },
+
         ready: function() {
             this._onHrefAttrChange(this.getAttribute('href'));
         },
 
-        _downloadPackage: function() {
+        _downloadPackage: function(successCB, errorCB) {
             if (this.debug) {
-                console.debug(logTag + 'Sending server request to install ' + this.package);
+                console.debug(LOG_TAG + 'Sending server request to install ' + this.package);
             }
 
             // Listen to the 'response' event to handle the ajax POST return value.
             this.$.ajaxPost.addEventListener('response', function(response) {
                 if (response && response.detail.status === 200) {
                     if (this.debug) {
-                        console.debug(logTag + 'Successfully installed ' + this.package);
+                        console.debug(LOG_TAG + 'Successfully installed ' + this.package);
                     }
 
                     // Add a dummy parameter to the url to force the browser
@@ -110,35 +145,25 @@
                     var url = new URL(this.href);
                     url.search += '&urthdummy=urth';
 
-                    this.importHref(url.href, function() {
-                        // Save the fact that the link href was loaded successfully.
-                        loadedPackages[this.href] = true;
-                        this.fire('load');
-                        if (this.debug) {
-                            console.debug(logTag + 'Successfully imported ' + url.href);
-                        }
-                    }.bind(this), function(e) {
-                        var msg = 'Failed to import ' + url.href;
-                        console.warn(logTag + msg);
-                        this.fire('importerror', { msg: msg });
+                    this.importHref(url.href, successCB, function(e) {
+                        errorCB.call(this, 'Failed to import ' + this.href);
                     }.bind(this));
-                } else {
+                } else if (typeof errorCB === 'function') {
                     // Assuming an error has occurred.
-                    var msg = 'Failed to send request to server.';
-                    console.warn(logTag + msg);
-                    this.fire('importerror', { msg: msg });
+                    errorCB.call(this, 'Failed to send request to server for ' + this.href);
                 }
             }.bind(this));
 
             // `iron-ajax` sets xhr errors on the `error` event.
-            this.$.ajaxPost.addEventListener('error', function(error) {
-                var msg = error && error.detail && error.detail.request &&
-                        error.detail.request.statusText ?
-                        error.detail.request.statusText :
-                        error.detail.error;
-                console.warn(logTag + msg);
-                this.fire('importerror', { msg: msg });
-            }.bind(this));
+            if (typeof errorCB === 'function') {
+                this.$.ajaxPost.addEventListener('error', function(error) {
+                    var msg = error && error.detail && error.detail.request &&
+                            error.detail.request.statusText ?
+                            error.detail.request.statusText :
+                            error.detail.error;
+                    errorCB.call(this, msg);
+                }.bind(this));
+            }
 
             this.$.ajaxPost.generateRequest();
         },
@@ -152,22 +177,16 @@
             if (newHref && this.rel === 'import') {
                 var prefixedHref = this._prefixHref(newHref);
                 if (prefixedHref !== newHref) {
+                    importBroker.addImport(this, newHref, this.package);
                     this.setAttribute('href', prefixedHref);
 
-                    this.importHref(this.href, function() {
-                        this.fire('load');
-                        if (this.debug) {
-                            console.debug(logTag + 'Successfully imported ' + this.href);
-                        }
-                    }.bind(this), function(e) {
+                    this.importHref(this.href, this._onLoadSuccess, function(e) {
                         // If the href doesn't load, try to download
                         // the package if it is specified.
                         if (this.package && !loadedPackages[this.href]) {
-                            this._downloadPackage();
+                            this._downloadPackage(this._onLoadSuccess, this._onLoadError);
                         } else {
-                            var msg = 'Failed to import ' + this.href;
-                            console.warn(logTag + msg);
-                            this.fire('importerror', { msg: msg });
+                            this._onLoadError('Failed to import ' + this.href);
                         }
                     }.bind(this));
                 }
@@ -177,6 +196,18 @@
         _onLinkLoad: function() {
             // Save the fact that the link href was loaded successfully.
             loadedPackages[this.href] = true;
+        },
+
+        _onLoadError: function(msg) {
+            console.warn(LOG_TAG + msg);
+            this.fire('importerror', { msg: msg });
+        },
+
+        _onLoadSuccess: function() {
+            this.fire('load');
+            if (this.debug) {
+                console.debug(LOG_TAG + 'Successfully imported ' + this.href);
+            }
         },
 
         _packageChanged: function(newVal, oldVal) {
@@ -199,4 +230,5 @@
             return baseURL + 'urth_import';
         }
     });
+})();
 </script>

--- a/etc/docs/urth-elements.html
+++ b/etc/docs/urth-elements.html
@@ -11,6 +11,7 @@
 <link rel='import' href='../../bower_components/urth-core-dataframe/urth-core-dataframe.html'>
 <link rel='import' href='../../bower_components/urth-core-function/urth-core-function.html'>
 <link rel='import' href='../../bower_components/urth-core-import/urth-core-import.html'>
+<link rel='import' href='../../bower_components/urth-core-import/urth-core-import-broker.html'>
 <link rel='import' href='../../bower_components/urth-core-storage/urth-core-storage.html'>
 <link rel='import' href='../../bower_components/urth-core-watch/urth-core-watch.html'>
 <link rel='import' href='../../bower_components/urth-viz-area/urth-viz-area.html'>

--- a/etc/notebooks/tests/urth-core-bind.ipynb
+++ b/etc/notebooks/tests/urth-core-bind.ipynb
@@ -1,0 +1,51 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### This test is used to verify that the `urth-core-bind` template waits for the dependency to load.\n",
+    "\n",
+    "This is a known scenario that fails if `urth-core-bind` does not wait for dependencies to load with shadow dom enabled (Chrome). Entering text into the `paper-input` should be duplicated in the `span`. If `urth-core-bind` does not wait for dependencies the `span` won't be updated."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "%%HTML\n",
+    "<link rel='import' href='urth_components/paper-input/paper-input.html' \n",
+    "        is='urth-core-import' package='PolymerElements/paper-input'>\n",
+    "<template id='bindtemplate' is='urth-core-bind'>    \n",
+    "    <span id='titleSpan'>[[title]]</span>\n",
+    "    <paper-input id='titleInput' label='Title' value='{{title}}'></paper-input>\n",
+    "</template>"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.4.4"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 0
+}

--- a/nb-extension/js/main.js
+++ b/nb-extension/js/main.js
@@ -6,6 +6,16 @@ define([
     './init/init'
 ], function(init) {
     'use strict';
+
+    // Some versions of IE do not have window.console defined. Some versions
+    // do not define the debug and other methods. This is a minimal workaround
+    // based on what declarative widgets code is using.
+    window.console = window.console || {};
+    window.console.log = window.console.log || function() {};
+    ['debug', 'error', 'trace', 'warn'].forEach(function(method) {
+        window.console[method] = window.console[method] || window.console.log;
+    });
+    
     init(IPython ? IPython.notebook.base_url : '/');
     return {
       load_ipython_extension: function() { console.debug('Custom JS loaded'); }

--- a/system-test/urth-core-bind-specs.js
+++ b/system-test/urth-core-bind-specs.js
@@ -1,0 +1,26 @@
+// Copyright (c) Jupyter Development Team.
+// Distributed under the terms of the Modified BSD License.
+
+var wd = require('wd');
+var Boilerplate = require('./utils/boilerplate');
+var boilerplate = new Boilerplate();
+
+describe('Urth Core Bind', function() {
+
+    boilerplate.setup(this.title, '/notebooks/tests/urth-core-bind.ipynb');
+
+    it('should run all cells and wait for dependency to load', function(done) {
+        // Using a random number to protect against the possibility of a previous
+        // test run value having been persisted.
+        var inputString = 'Hello ' + Math.random();
+
+        boilerplate.browser
+            .waitForElementById('titleInput', wd.asserters.isDisplayed, 10000)
+            .elementById('titleInput')
+            .click()
+            .keys(inputString)
+            .elementById('titleSpan')
+            .text().should.eventually.include(inputString)
+            .nodeify(done);
+    });
+});


### PR DESCRIPTION
Modified default behavior of `urth-core-bind` to not render until the previous dependencies (`urth-core-import` links) have completed. Specify the `no-wait` property to ignore dependencies and render immediately.

Added a singleton `urth-core-import-broker` element which is used to keep track of pending imports. Provides a method `getPendingImports` which returns promises to determine the status of the imports.

Added `loading` and `finished` events that fire on the `urth-core-import` element when the element is attached and when it has finished loading respectively. These events should bubble to the body so listeners can be attached to the body to track dependency loading.

Fixes #188
