### PR TITLE
Add new JupyterSaveBehavior for save events.

### DIFF
--- a/elements/urth-core-behaviors/jupyter-save-behavior.html
+++ b/elements/urth-core-behaviors/jupyter-save-behavior.html
@@ -1,0 +1,42 @@
+<!--
+# Copyright (c) Jupyter Development Team.
+# Distributed under the terms of the Modified BSD License.
+-->
+
+<script>
+    'use strict';
+    (function() {
+        var SAVE_EVENT = 'before_save.Notebook';
+        window.Urth = window.Urth || {};
+
+        /**
+         * Behavior that provides registration with the save event. Elements
+         * that implement this behavior must implement the `onSave` method to
+         * define the element specific save procedure.
+         *
+         * @group Urth Core
+         * @polymerBehavior Urth.JupyterSaveBehavior
+         */
+        Urth.JupyterSaveBehavior = {
+            created: function(event, callback) {
+                if (window.IPython && window.IPython.notebook && window.IPython.notebook.events) {
+                    this.__saveCallback = this.onSave.bind(this);
+                    IPython.notebook.events.on(SAVE_EVENT, this.__saveCallback);
+                }
+            },
+
+            detached: function(event, callback) {
+                if (this.__saveCallback) {
+                    IPython.notebook.events.off(SAVE_EVENT, this.__saveCallback);
+                }
+            },
+
+            /**
+             * Element specific handler for the save event.
+             *
+             * @method onSave
+             */
+            onSave: function() {}
+        };
+    })();
+</script>

--- a/elements/urth-core-behaviors/jupyter-widget-behavior.html
+++ b/elements/urth-core-behaviors/jupyter-widget-behavior.html
@@ -244,42 +244,13 @@ This behavior is used to encapsulate some of the services needed for ipywidgets.
             },
 
             /**
-             * returns the model's __status__ object, 
+             * returns the model's __status__ object,
              * so elements who has this behavior can check for error if __status__.status is "error"
              *
              * @method getModelStatusMsg
              */
             getModelStatusMsg: function() {
                 return this._statusMsg || { status: 'ok', msg: '' };
-            },
-
-            /**
-             * Registers a function to be invoked when the specified Jupyter
-             * notebook event occurs.
-             *
-             * @method addEventCallback
-             * @param {String} event The IPython notebook event.
-             * @param {Function} callback The function to invoke.
-             */
-            addEventCallback: function(event, callback) {
-                if (window.IPython && window.IPython.notebook && window.IPython.notebook.events) {
-                    IPython.notebook.events.on(event, callback);
-                }
-            },
-
-            /**
-             * Removes a previously registered callback function for a Jupyter
-             * notebook event.
-             *
-             * @method removeEventCallback
-             * @param {String} event The IPython notebook event.
-             * @param {Function} callback The function that was previously
-             * registered.
-             */
-            removeEventCallback: function(event, callback) {
-                if (window.IPython && window.IPython.notebook && window.IPython.notebook.events) {
-                    IPython.notebook.events.off(event, callback);
-                }
             }
         };
 

--- a/elements/urth-core-behaviors/test/jupyter-save-behavior.html
+++ b/elements/urth-core-behaviors/test/jupyter-save-behavior.html
@@ -1,0 +1,107 @@
+<!doctype html>
+<!--
+# Copyright (c) Jupyter Development Team.
+# Distributed under the terms of the Modified BSD License.
+-->
+<html>
+<head>
+    <meta charset="utf-8">
+    <!-- STEP 1: Provide a title for the test suite. -->
+    <title>urth-core-function tests</title>
+    <meta name='viewport' content='width=device-width, minimum-scale=1.0, initial-scale=1.0, user-scalable=yes'>
+
+    <!-- Need the web component polyfill for browsers without native support. -->
+    <script src='../../webcomponentsjs/webcomponents-lite.js'></script>
+
+    <!-- Load test framework and helpers. -->
+    <script src='../../web-component-tester/browser.js'></script>
+    <script src='../../test-fixture/test-fixture-mocha.js'></script>
+    <link rel='import' href='../../polymer/polymer.html'>
+    <link rel='import' href='../../test-fixture/test-fixture.html'>
+
+    <!-- STEP 2: Import the element to test. -->
+    <link rel='import' href='../jupyter-save-behavior.html'>
+
+</head>
+
+<body>
+
+    <!-- STEP 3: Setup document with DOM to test. Use test-fixture elements
+         to ease setup and cleanup of elements. -->
+
+    <test-fixture id='basic'>
+        <template>
+            <test-save id='testSave'></test-save>
+        </template>
+    </test-fixture>
+
+    <!-- This is a custom element that will be used to test
+         save invocation. -->
+    <dom-module id="test-save">
+        <script>
+            HTMLImports.whenReady(function () {
+                Polymer({
+                    is: 'test-save',
+                    behaviors: [ Urth.JupyterSaveBehavior],
+                    onSave: function() {
+                        if (this._saveHandler) {
+                            this._saveHandler();
+                        }
+                    },
+                    setSaveHandler: function(cb) {
+                        if (typeof cb === 'function') {
+                            this._saveHandler = cb;
+                        }
+                    }
+                });
+            });
+        </script>
+    </dom-module>
+
+    <script>
+        // STEP 4: Define any globals needed by the test suite.
+
+        before(function () {
+            window.IPython = window.IPython || {};
+            IPython.notebook = IPython.notebook || {};
+            IPython.notebook.events = IPython.notebook.events || new function() {
+                this.__mocked = true;
+                this.__events = {};
+                this.on = function(event, cb) {
+                    this.__events[event] = cb;
+                };
+                this.off = function(event, cb) {
+                    if (this.__events[event] === cb) {
+                        delete this.__events[event];
+                    }
+                },
+                this.trigger = function(event, obj) {
+                    if (this.__events[event]) {
+                        this.__events[event](obj);
+                    }
+                }
+            };
+        });
+
+        after(function() {
+            if (IPython.notebook.events.__mocked) {
+                delete IPython.notebook.events;
+            }
+        });
+
+        // STEP 5: Define suite(s) and tests.
+        describe('save event', function() {
+            it('should invoke the onSave method of elements that implement the behavior', function() {
+                var testSave = fixture('basic');
+                var saveSpy = sinon.spy();
+
+                testSave.setSaveHandler(saveSpy);
+
+                IPython.notebook.events.trigger('before_save.Notebook');
+
+                expect(saveSpy).to.have.been.calledOnce;
+            });
+        });
+    </script>
+</body>
+</html>

--- a/elements/urth-core-channel/urth-core-channel-broker.html
+++ b/elements/urth-core-channel/urth-core-channel-broker.html
@@ -5,6 +5,7 @@
 <link rel="import" href="../polymer/polymer.html">
 <link rel="import" href="../urth-core-behaviors/jupyter-widget-behavior.html">
 <link rel="import" href="../urth-core-behaviors/jupyter-kernel-observer.html">
+<link rel="import" href="../urth-core-behaviors/jupyter-save-behavior.html">
 <link rel="import" href="../urth-core-storage/urth-core-storage.html">
 
 <!--
@@ -53,7 +54,8 @@ var broker = window.Urth['urth-core-channel-broker'].getChannelBroker();
             is: 'urth-core-channel-broker',
             behaviors: [
                 Urth.JupyterWidgetBehavior,
-                Urth.JupyterKernelObserver
+                Urth.JupyterKernelObserver,
+                Urth.JupyterSaveBehavior
             ],
 
             /**
@@ -103,13 +105,6 @@ var broker = window.Urth['urth-core-channel-broker'].getChannelBroker();
 
                     // Remove the channel data from storage.
                     this.$.storage.remove(globalChannel.name);
-                }
-            },
-
-            detached: function() {
-                // Remove any event listeners that were previously added.
-                if (this._saveHandler) {
-                    this.removeEventCallback('before_save.Notebook', this._saveHandler);
                 }
             },
 
@@ -168,10 +163,15 @@ var broker = window.Urth['urth-core-channel-broker'].getChannelBroker();
                 console.debug('urth-core-channel-broker onModelReady');
             },
 
-            ready: function() {
-                // Add event listener for saves of the notebook.
-                this._saveHandler = this._saveAll.bind(this);
-                this.addEventCallback('before_save.Notebook', this._saveHandler);
+            /**
+             * Saves the data in all of the currently defined channels.
+             *
+             * @method onSave
+             */
+            onSave: function() {
+                Object.keys(_globalChannels).forEach(function(channel) {
+                    this.save(channel);
+                }.bind(this));
             },
 
             /**
@@ -303,12 +303,6 @@ var broker = window.Urth['urth-core-channel-broker'].getChannelBroker();
                 channelName = channelName || this.name || 'default';
                 var channel = this._getGlobalChannel(channelName);
                 return channel ? channel : this._createGlobalChannel(channelName);
-            },
-
-            _saveAll: function() {
-                Object.keys(_globalChannels).forEach(function(channel) {
-                    this.save(channel);
-                }.bind(this));
             },
 
             /**

--- a/etc/docs/urth-elements.html
+++ b/etc/docs/urth-elements.html
@@ -3,6 +3,7 @@
 # Distributed under the terms of the Modified BSD License.
 -->
 <link rel='import' href='../../bower_components/urth-core-behaviors/jupyter-kernel-observer.html'>
+<link rel='import' href='../../bower_components/urth-core-behaviors/jupyter-save-behavior.html'>
 <link rel='import' href='../../bower_components/urth-core-behaviors/jupyter-widget-behavior.html'>
 <link rel='import' href='../../bower_components/urth-core-bind/urth-core-bind.html'>
 <link rel='import' href='../../bower_components/urth-core-channel/urth-core-channel.html'>


### PR DESCRIPTION
Removes the general `addEventCallback` and `removeEventCallback` from `jupyter-widget-behavior.html` in favor of a specific save behavior `jupyter-save-behavior.html`.

Fixes #180 
