### PR TITLE
Update to build scala support on top of Toree

### DIFF
--- a/etc/notebooks/examples/urth-scala-widgets.ipynb
+++ b/etc/notebooks/examples/urth-scala-widgets.ipynb
@@ -515,20 +515,11 @@
    "source": [
     "channel(\"c\").set(\"x\", List(0, 1, 2))"
    ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "collapsed": true
-   },
-   "outputs": [],
-   "source": []
   }
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Scala 2.10.4",
+   "display_name": "Apache Toree (Scala 2.10.4)",
    "language": "scala",
    "name": "scala"
   },

--- a/kernel-scala/build.sbt
+++ b/kernel-scala/build.sbt
@@ -8,16 +8,15 @@ version := "0.1-SNAPSHOT"
 
 scalaVersion := "2.10.4"
 
-val kernelVersion = "0.1.5-SNAPSHOT"
+/*
+  Toree is brought in as an unmanaged dependency
+ */
 
 val sparkVersion = "1.5.1"
 
 libraryDependencies ++= Seq(
   "org.apache.spark" %% "spark-core" % sparkVersion  % "provided",
   "org.apache.spark" %% "spark-repl" % sparkVersion  % "provided",
-  "com.ibm.spark" %% "kernel" % kernelVersion % "provided",
-  "com.ibm.spark" %% "kernel-api" % kernelVersion % "provided",
-  "com.ibm.spark" %% "protocol" % kernelVersion % "provided",
   "org.scalatest" %% "scalatest" % "2.2.0" % "test", // Apache v2
   "org.scalactic" %% "scalactic" % "2.2.0" % "test", // Apache v2
   "org.mockito" % "mockito-all" % "1.9.5" % "test"   // MIT

--- a/kernel-scala/src/main/scala/urth/widgets/Widget.scala
+++ b/kernel-scala/src/main/scala/urth/widgets/Widget.scala
@@ -5,9 +5,9 @@
 
 package urth.widgets
 
-import com.ibm.spark.comm.CommWriter
-import com.ibm.spark.kernel.protocol.v5.{MsgData, UUID}
-import com.ibm.spark.utils.LogLike
+import org.apache.toree.comm.CommWriter
+import org.apache.toree.kernel.protocol.v5.{MsgData, UUID}
+import org.apache.toree.utils.LogLike
 import play.api.libs.json.{Json, JsValue}
 import urth.widgets.exceptions.WidgetNotAvailableException
 import urth.widgets.util.MessageSupport

--- a/kernel-scala/src/main/scala/urth/widgets/WidgetChannels.scala
+++ b/kernel-scala/src/main/scala/urth/widgets/WidgetChannels.scala
@@ -1,8 +1,8 @@
 package urth.widgets
 
-import com.ibm.spark.comm.CommWriter
-import com.ibm.spark.kernel.protocol.v5.MsgData
-import com.ibm.spark.utils.LogLike
+import org.apache.toree.comm.CommWriter
+import org.apache.toree.kernel.protocol.v5.MsgData
+import org.apache.toree.utils.LogLike
 import play.api.libs.json.{JsNull, JsValue}
 import urth.widgets.util.{StandardFunctionSupport, MessageSupport, SerializationSupport}
 

--- a/kernel-scala/src/main/scala/urth/widgets/WidgetDataFrame.scala
+++ b/kernel-scala/src/main/scala/urth/widgets/WidgetDataFrame.scala
@@ -5,9 +5,9 @@
 
 package urth.widgets
 
-import com.ibm.spark.comm.CommWriter
-import com.ibm.spark.interpreter.Interpreter
-import com.ibm.spark.kernel.protocol.v5.MsgData
+import org.apache.toree.comm.CommWriter
+import org.apache.toree.interpreter.Interpreter
+import org.apache.toree.kernel.protocol.v5.MsgData
 import play.api.libs.json.JsValue
 import urth.widgets.util.SerializationSupport
 

--- a/kernel-scala/src/main/scala/urth/widgets/WidgetFunction.scala
+++ b/kernel-scala/src/main/scala/urth/widgets/WidgetFunction.scala
@@ -5,8 +5,8 @@
 
 package urth.widgets
 
-import com.ibm.spark.comm.CommWriter
-import com.ibm.spark.kernel.protocol.v5.MsgData
+import org.apache.toree.comm.CommWriter
+import org.apache.toree.kernel.protocol.v5.MsgData
 import play.api.libs.json.{JsString, JsValue, Json}
 import urth.widgets.util.{SerializationSupport, StandardFunctionSupport}
 

--- a/kernel-scala/src/main/scala/urth/widgets/package.scala
+++ b/kernel-scala/src/main/scala/urth/widgets/package.scala
@@ -5,7 +5,7 @@
 
 package urth
 
-import com.ibm.spark.kernel.api.Kernel
+import org.apache.toree.kernel.api.Kernel
 import org.apache.spark.repl.SparkIMain
 
 package object widgets {

--- a/kernel-scala/src/main/scala/urth/widgets/util/FunctionSupport.scala
+++ b/kernel-scala/src/main/scala/urth/widgets/util/FunctionSupport.scala
@@ -5,7 +5,7 @@
 
 package urth.widgets.util
 
-import com.ibm.spark.interpreter.Interpreter
+import org.apache.toree.interpreter.Interpreter
 import play.api.libs.json._
 
 import scala.util.{Failure, Success, Try}
@@ -13,7 +13,7 @@ import scala.util.{Failure, Success, Try}
 import urth.widgets._
 import org.apache.spark.repl.SparkIMain
 
-import com.ibm.spark.utils.LogLike
+import org.apache.toree.utils.LogLike
 
 import scala.reflect.runtime.universe._
 

--- a/kernel-scala/src/main/scala/urth/widgets/util/MessageSupport.scala
+++ b/kernel-scala/src/main/scala/urth/widgets/util/MessageSupport.scala
@@ -1,7 +1,7 @@
 package urth.widgets.util
 
-import com.ibm.spark.comm.CommWriter
-import com.ibm.spark.utils.LogLike
+import org.apache.toree.comm.CommWriter
+import org.apache.toree.utils.LogLike
 import play.api.libs.json.{Json, JsValue}
 import urth.widgets.Comm
 

--- a/kernel-scala/src/main/scala/urth/widgets/util/SerializationSupport.scala
+++ b/kernel-scala/src/main/scala/urth/widgets/util/SerializationSupport.scala
@@ -5,7 +5,7 @@
 
 package urth.widgets.util
 
-import com.ibm.spark.utils.LogLike
+import org.apache.toree.utils.LogLike
 import org.apache.spark.sql.DataFrame
 import play.api.libs.json._
 import urth.widgets.Default

--- a/kernel-scala/src/test/scala/urth/widgets/WidgetChannelsSpec.scala
+++ b/kernel-scala/src/test/scala/urth/widgets/WidgetChannelsSpec.scala
@@ -1,7 +1,7 @@
 package urth.widgets
 
-import com.ibm.spark.comm.CommWriter
-import com.ibm.spark.kernel.protocol.v5._
+import org.apache.toree.comm.CommWriter
+import org.apache.toree.kernel.protocol.v5._
 import org.mockito.Matchers._
 import org.scalatest.mock.MockitoSugar
 import org.scalatest.{Matchers, FunSpec}

--- a/kernel-scala/src/test/scala/urth/widgets/WidgetDataFrameSpec.scala
+++ b/kernel-scala/src/test/scala/urth/widgets/WidgetDataFrameSpec.scala
@@ -5,8 +5,8 @@
 
 package urth.widgets
 
-import com.ibm.spark.comm.CommWriter
-import com.ibm.spark.interpreter.Interpreter
+import org.apache.toree.comm.CommWriter
+import org.apache.toree.interpreter.Interpreter
 import org.mockito.Matchers._
 import org.mockito.Mockito._
 import org.scalatest.FunSpec

--- a/kernel-scala/src/test/scala/urth/widgets/WidgetFunctionSpec.scala
+++ b/kernel-scala/src/test/scala/urth/widgets/WidgetFunctionSpec.scala
@@ -5,8 +5,8 @@
 
 package urth.widgets
 
-import com.ibm.spark.comm.CommWriter
-import com.ibm.spark.kernel.protocol.v5.MsgData
+import org.apache.toree.comm.CommWriter
+import org.apache.toree.kernel.protocol.v5.MsgData
 import org.mockito.Matchers._
 import org.mockito.Mockito._
 import org.scalatest.mock.MockitoSugar

--- a/kernel-scala/src/test/scala/urth/widgets/WidgetSpec.scala
+++ b/kernel-scala/src/test/scala/urth/widgets/WidgetSpec.scala
@@ -5,8 +5,8 @@
 
 package urth.widgets
 
-import com.ibm.spark.comm.CommWriter
-import com.ibm.spark.kernel.protocol.v5.MsgData
+import org.apache.toree.comm.CommWriter
+import org.apache.toree.kernel.protocol.v5.MsgData
 import org.scalatest.mock.MockitoSugar
 import org.scalatest.{Matchers, FunSpec}
 import play.api.libs.json.{JsString, Json}

--- a/kernel-scala/src/test/scala/urth/widgets/util/MessageSupportSpec.scala
+++ b/kernel-scala/src/test/scala/urth/widgets/util/MessageSupportSpec.scala
@@ -1,6 +1,6 @@
 package urth.widgets.util
 
-import com.ibm.spark.comm.CommWriter
+import org.apache.toree.comm.CommWriter
 import org.mockito.Mockito._
 import org.scalatest.mock.MockitoSugar
 import org.scalatest.{Matchers, FunSpec}


### PR DESCRIPTION
I'm still using `cloudet/sbt-sparkkernel-image:1.5.1` for its support of sbt and scala, but I'm bringing in Toree straight from pip and using the assembly jar.

The jar is then referred to as an unmanaged dependency in the build.sbt of the kernel-scala module.
