### PR TITLE
Use GET instead of HEAD. Switch to urth_components dir.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -73,12 +73,12 @@ dist/urth_widgets/elements: ${shell find elements}
 	@cp -R elements/* dist/urth_widgets/elements/.
 	@touch dist/urth_widgets/elements
 
-dist/urth_widgets/bower_components: bower_components ${shell find elements} | $(URTH_COMP_LINKS)
+dist/urth_widgets/urth_components: bower_components ${shell find elements} | $(URTH_COMP_LINKS)
 	@echo 'Moving bower_components'
-	@mkdir -p dist/urth_widgets/bower_components
-	@cp -RL bower_components/* dist/urth_widgets/bower_components/.
+	@mkdir -p dist/urth_widgets/urth_components
+	@cp -RL bower_components/* dist/urth_widgets/urth_components/.
 
-dist/urth_widgets: dist/urth_widgets/bower_components dist/urth_widgets/js dist/urth_widgets/elements
+dist/urth_widgets: dist/urth_widgets/urth_components dist/urth_widgets/js dist/urth_widgets/elements
 
 dist/urth/widgets/ext: ${shell find nb-extension/python/urth/widgets/ext}
 	@echo 'Moving frontend extension code'

--- a/nb-extension/python/urth/widgets/ext/urth_import.py
+++ b/nb-extension/python/urth/widgets/ext/urth_import.py
@@ -94,19 +94,20 @@ def load_jupyter_server_extension(nb_app):
         with open(bowerrc, 'a') as f:
             f.write("""{
             "analytics": false,
-            "interactive": false
+            "interactive": false,
+            "directory": "urth_components"
             }""")
 
     # The import handler serves from /urth_import and any requests
-    # containing /urth_components/ will get served from the bower_components
-    # directory.
+    # containing /urth_components/ will get served from the actual
+    # urth_components directory.
     import_route_pattern = url_path_join(web_app.settings['base_url'], '/urth_import')
     components_route_pattern = url_path_join(web_app.settings['base_url'], '/urth_components/(.*)')
-    bower_path = os.path.join(widgets_dir, 'bower_components/')
+    components_path = os.path.join(widgets_dir, 'urth_components/')
 
     # Register the Urth import handler and static file handler.
     logger.debug('Adding handlers for {0} and {1}'.format(import_route_pattern, components_route_pattern))
     web_app.add_handlers('.*$', [
         (import_route_pattern, UrthImportHandler, dict(executor=ThreadPoolExecutor(max_workers=1))),
-        (components_route_pattern, FileFindHandler, {'path': [bower_path]})
+        (components_route_pattern, FileFindHandler, {'path': [components_path]})
     ])


### PR DESCRIPTION
System tests were failing on Sauce Labs due to the `HEAD` request that was added in commit abb6867. This change switches to using `GET` instead and renames the server side `bower_components` to `urth_components` for consistent referencing.
