### PR TITLE
Set initial display to 'none' for dropdowns.  Fixes #222

### DIFF
--- a/elements/urth-viz-chart/urth-viz-chart.css
+++ b/elements/urth-viz-chart/urth-viz-chart.css
@@ -1,1 +1,2 @@
 #chart1 .selected { fill: yellow !important; }
+#settings-section { display: none; }


### PR DESCRIPTION
(c) Copyright IBM Corp. 2016
