### PR TITLE
Support complex data in channels

### DIFF
--- a/elements/urth-core-bind/test/urth-core-bind.html
+++ b/elements/urth-core-bind/test/urth-core-bind.html
@@ -198,7 +198,6 @@
             });
 
             it('should not retrieve the pending imports if "no-wait" is specified', function() {
-                debugger;
                 var importBroker = window.Urth['urth-core-import-broker'].getImportBroker();
                 var importSpy = sinon.spy(importBroker, 'getPendingImports');
                 var renderTemplate = new window.Urth['urth-core-bind']();

--- a/elements/urth-core-bind/urth-core-bind.html
+++ b/elements/urth-core-bind/urth-core-bind.html
@@ -135,7 +135,7 @@
                 // value change. Channel change is handled separately.
                 if (newVal !== oldVal && property !== 'channel' &&
                         property !== 'noWait') {
-                    this.channelElement.set(property, newVal);
+                    this.channelElement.set(property, newVal, { oldValue: oldVal });
                 }
             }
         });

--- a/elements/urth-core-channel/test/urth-core-channel-broker.html
+++ b/elements/urth-core-channel/test/urth-core-channel-broker.html
@@ -148,6 +148,10 @@
                 expect(channel1.get('foo')).to.be.undefined;
                 expect(channel1.get('bar')).to.be.undefined;
             });
+
+            it('can be invoked on a non-existant channel', function() {
+                broker.clear('doesnotexist');
+            });
         });
 
         describe('get', function() {
@@ -166,6 +170,27 @@
                 broker.set(undefined, 'foo', 'bar');
 
                 expect(broker.get(undefined, 'foo')).to.equal(channelDefault.get('foo'));
+            });
+
+            it('should retrieve the value for the specified array path', function() {
+                var fooArray = [
+                    {name: 'foo', value: 'bar'},
+                    {name: 'bar', value: 'none'}
+                ];
+                broker.set(channel1.name, 'fooArray', fooArray);
+
+                expect(broker.get(channel1.name, 'fooArray.#0.value')).to.equal('bar');
+            });
+
+            it('should retrieve the value for the specified object path', function() {
+                var fooObj = {
+                    name: 'foo',
+                    value: 'bar'
+                };
+
+                broker.set(channel1.name, 'fooObj', fooObj);
+
+                expect(broker.get(channel1.name, 'fooObj.value')).to.equal('bar');
             });
         });
 
@@ -282,6 +307,14 @@
         });
 
         describe('set', function() {
+            it('should not error if channelName is not specified', function() {
+                broker.set(undefined, 'foo', 'bar');
+            });
+
+            it ('should not error if key is not specified', function() {
+                broker.set(channel1.name, undefined, 'bar');
+            });
+
             it('should save the specified key and value', function() {
                 broker.set(channel1.name, 'foo', 'bar');
 
@@ -315,6 +348,67 @@
                 expect(sendArgs.data.channel).to.equal(channel1.name);
             });
 
+            it('should not send the update to the model if the value did not change', function() {
+                broker.set(channel1.name, 'foo', 'bar');
+                broker.set(channel1.name, 'fooArray', [{user: 'foo', value: 'sure'}]);
+                broker.set(channel1.name, 'fooObj', {user: 'foo', value: 'yes'});
+
+                var sendSpy = sinon.spy(broker, 'send');
+                broker.set(channel1.name, 'foo', 'bar');
+                broker.set(channel1.name, 'fooArray', [{user: 'foo', value: 'sure'}]);
+                broker.set(channel1.name, 'fooObj', {user: 'foo', value: 'yes'});
+
+                sendSpy.restore();
+
+                expect(sendSpy).to.have.not.been.called;
+            });
+
+            it('should send the array to the model when an item in the array is modifed', function() {
+                var fooArray = [
+                    {name: 'foo', value: 'new'},
+                    {name: 'bar', value: 'it'}
+                ];
+                broker.set(channel1.name, 'fooArray', fooArray);
+                var sendSpy = sinon.spy(broker, 'send');
+                broker.set(channel1.name, 'fooArray.#0.value', 'bar');
+
+                sendSpy.restore();
+
+                var sendArgs = sendSpy.getCall(0).args[0];
+                expect(sendSpy).to.have.been.called;
+                expect(sendArgs.event).to.equal('change');
+                expect(sendArgs.data.name).to.equal('fooArray');
+                expect(sendArgs.data.new_val).to.deep.equal([
+                    {name: 'foo', value: 'bar'},
+                    {name: 'bar', value: 'it'}
+                ]);
+                expect(sendArgs.data.old_val).to.deep.equal([
+                    {name: 'foo', value: 'new'},
+                    {name: 'bar', value: 'it'}
+                ]);
+                expect(sendArgs.data.channel).to.equal(channel1.name);
+            });
+
+            it('should send the object to the model when a property of the object is modifed', function() {
+                var fooObj = {
+                    name: 'foo',
+                    value: 'not'
+                };
+                broker.set(channel1.name, 'fooObj', fooObj);
+                var sendSpy = sinon.spy(broker, 'send');
+                broker.set(channel1.name, 'fooObj.value', 'shizle');
+
+                sendSpy.restore();
+
+                var sendArgs = sendSpy.getCall(0).args[0];
+                expect(sendSpy).to.have.been.called;
+                expect(sendArgs.event).to.equal('change');
+                expect(sendArgs.data.name).to.equal('fooObj');
+                expect(sendArgs.data.new_val).to.deep.equal({name: 'foo', value: 'shizle'});
+                expect(sendArgs.data.old_val).to.deep.equal({name: 'foo', value: 'not'});
+                expect(sendArgs.data.channel).to.equal(channel1.name);
+            });
+
             it('should fire the "urth-channel-data-update" event on registered channel elements', function() {
                 broker.addChannelElement(channel1.name, channel1);
                 broker.addChannelElement(channel2.name, channel2);
@@ -338,6 +432,109 @@
                 expect(eventArgs.oldValue).to.equal('shizel');
                 expect(eventArgs.value).to.equal('bar');
                 expect(eventSpy2).to.not.have.been.called;
+            });
+
+            it('should fire the "urth-channel-data-update" event on registered channel elements and include root info for array path modifications', function() {
+                broker.addChannelElement(channel1.name, channel1);
+                broker.addChannelElement(channel2.name, channel2);
+
+                var fooArray = [
+                    {name: 'foo', value: 'sure'},
+                    {name: 'bar', value: 'not'}
+                ];
+                broker.set(channel1.name, 'fooArray', fooArray);
+
+                var eventSpy = sinon.spy();
+                var eventSpy2 = sinon.spy();
+
+                channel1.addEventListener('urth-channel-data-update', eventSpy);
+
+                broker.set(channel1.name, 'fooArray.#0.value', 'shizel');
+
+                channel1.removeEventListener('urth-channel-data-update', eventSpy);
+
+                var eventArgs = eventSpy.getCall(0).args[0].detail;
+                expect(eventSpy).to.have.been.calledOnce;
+                expect(eventArgs.key).to.equal('fooArray.#0.value');
+                expect(eventArgs.oldValue).to.equal('sure');
+                expect(eventArgs.value).to.equal('shizel');
+                expect(eventArgs.root).to.deep.equal({
+                    key: 'fooArray',
+                    oldValue: [
+                        {name: 'foo', value: 'sure'},
+                        {name: 'bar', value: 'not'}
+                    ],
+                    value: [
+                        {name: 'foo', value: 'shizel'},
+                        {name: 'bar', value: 'not'}
+                    ]
+                });
+            });
+
+            it('should fire the "urth-channel-data-update" event on registered channel elements and include root info for object property modifications', function() {
+                broker.addChannelElement(channel1.name, channel1);
+                broker.addChannelElement(channel2.name, channel2);
+
+                var fooObj = {
+                    name: 'foo',
+                    value: 'who'
+                };
+                broker.set(channel1.name, 'fooObj', fooObj);
+
+                var eventSpy = sinon.spy();
+
+                channel1.addEventListener('urth-channel-data-update', eventSpy);
+
+                broker.set(channel1.name, 'fooObj.value', 'you');
+
+                channel1.removeEventListener('urth-channel-data-update', eventSpy);
+
+                var eventArgs = eventSpy.getCall(0).args[0].detail;
+                expect(eventSpy).to.have.been.calledOnce;
+                expect(eventArgs.key).to.equal('fooObj.value');
+                expect(eventArgs.oldValue).to.equal('who');
+                expect(eventArgs.value).to.equal('you');
+                expect(eventArgs.root).to.deep.equal({
+                    key: 'fooObj',
+                    oldValue: {name: 'foo', value: 'who'},
+                    value: {name: 'foo', value: 'you'}
+                });
+            });
+
+            it('should set the specified array path', function() {
+                var fooArray = [
+                    {name: 'foo', value: 'shoo'},
+                    {name: 'bar', value: 'open'}
+                ];
+                broker.set(channel1.name, 'fooArray', fooArray);
+
+                broker.set(channel1.name, 'fooArray.#0.value', 'too');
+                broker.set(channel1.name, 'fooArray.#1.value', 'closed')
+
+                expect(broker.get(channel1.name, 'fooArray.#0.value')).to.equal('too');
+                expect(broker.get(channel1.name, 'fooArray.#1.value')).to.equal('closed');
+                expect(broker.get(channel1.name, 'fooArray')).to.deep.equal([
+                    {name: 'foo', value: 'too'},
+                    {name: 'bar', value: 'closed'}
+                ]);
+            });
+
+            it('should set the specified object property', function() {
+                var fooObj = {
+                    name: 'foo',
+                    value: 'bar'
+                };
+                broker.set(channel1.name, 'fooObj', fooObj);
+
+                broker.set(channel1.name, 'fooObj.name', 'foot');
+                broker.set(channel1.name, 'fooObj.value', 'ball')
+
+                expect(broker.get(channel1.name, 'fooObj.name')).to.equal('foot');
+                expect(broker.get(channel1.name, 'fooObj.value')).to.equal('ball');
+                expect(broker.get(channel1.name, 'fooObj')).to.deep.equal({
+                    name: 'foot',
+                    value: 'ball'
+                });
             });
         });
     </script>

--- a/elements/urth-core-channel/test/urth-core-channel.html
+++ b/elements/urth-core-channel/test/urth-core-channel.html
@@ -549,6 +549,76 @@
                 expect(watch2SpyArgs[1]).to.equal('none');
                 expect(watch2SpyArgs[2]).to.equal('open');
             });
+
+            it('should register an array watcher that gets invoked when an item from the array is modified.', function() {
+                var foo = [
+                    {name: 'bar', value: 'none'},
+                    {name: 'open', value: 'yes'}
+                ];
+                channel.set('foo', foo);
+                var watchSpy = sinon.spy();
+                var propSpy = sinon.spy();
+
+                // Modifying an item in the array should call watchers for the
+                // top level array and for the path that was modified.
+                channel.watch('foo', watchSpy);
+                channel.watch('foo.#1.value', propSpy);
+
+                channel.set('foo.#1.value', 'no');
+
+                expect(watchSpy).to.have.been.calledOnce;
+                var watchSpyArgs = watchSpy.getCall(0).args;
+                expect(watchSpyArgs[0]).to.equal('foo');
+                expect(watchSpyArgs[1]).to.deep.equal([
+                    {name: 'bar', value: 'none'},
+                    {name: 'open', value: 'yes'}
+                ]);
+                expect(watchSpyArgs[2]).to.deep.equal([
+                    {name: 'bar', value: 'none'},
+                    {name: 'open', value: 'no'}
+                ]);
+
+                expect(propSpy).to.have.been.calledOnce;
+                var propSpyArgs = propSpy.getCall(0).args;
+                expect(propSpyArgs[0]).to.equal('foo.#1.value');
+                expect(propSpyArgs[1]).to.equal('yes');
+                expect(propSpyArgs[2]).to.equal('no');
+            });
+
+            it('should register an object watcher that gets invoked when a property from the object is modified.', function() {
+                var foo = {
+                    name: 'bar',
+                    value: 'none'
+                };
+                channel.set('foo', foo);
+                var watchSpy = sinon.spy();
+                var propSpy = sinon.spy();
+
+                // Modifying a property in an object should call watchers for the
+                // top level object and for the path that was modified.
+                channel.watch('foo', watchSpy);
+                channel.watch('foo.value', propSpy);
+
+                channel.set('foo.value', 'all');
+
+                expect(watchSpy).to.have.been.calledOnce;
+                var watchSpyArgs = watchSpy.getCall(0).args;
+                expect(watchSpyArgs[0]).to.equal('foo');
+                expect(watchSpyArgs[1]).to.deep.equal({
+                    name: 'bar',
+                    value: 'none'
+                });
+                expect(watchSpyArgs[2]).to.deep.equal({
+                    name: 'bar',
+                    value: 'all'
+                });
+
+                expect(propSpy).to.have.been.calledOnce;
+                var propSpyArgs = propSpy.getCall(0).args;
+                expect(propSpyArgs[0]).to.equal('foo.value');
+                expect(propSpyArgs[1]).to.equal('none');
+                expect(propSpyArgs[2]).to.equal('all');
+            });
         });
     </script>
 </body>

--- a/elements/urth-core-channel/urth-core-channel-broker.html
+++ b/elements/urth-core-channel/urth-core-channel-broker.html
@@ -38,7 +38,6 @@ var broker = window.Urth['urth-core-channel-broker'].getChannelBroker();
             return {
                 'elements': [],
                 'data': {},
-                'initialized': false,
                 'name': channelName
             };
         };
@@ -75,11 +74,14 @@ var broker = window.Urth['urth-core-channel-broker'].getChannelBroker();
              * @return {Object} The data currently set on the specified channel.
              */
             addChannelElement: function(channelName, element) {
-                var channel = this._getOrCreateGlobalChannel(channelName);
-                var data = channel ? channel.data : {};
+                var data;
+                var globalChannel = this._getOrCreateGlobalChannel(channelName);
+                if (globalChannel && element) {
+                    data = Polymer.Base.get(globalChannel.name, this);
 
-                if (element && channel && channel.elements.indexOf(element) === -1) {
-                    channel.elements.push(element);
+                    if (globalChannel.elements.indexOf(element) === -1) {
+                        globalChannel.elements.push(element);
+                    }
                 }
 
                 return data;
@@ -97,11 +99,12 @@ var broker = window.Urth['urth-core-channel-broker'].getChannelBroker();
                     // Iterate through all the properties and unset
                     // them so registered elements get notified of
                     // the data clear.
-                    Object.keys(globalChannel.data).forEach(function(key) {
+                    var data = Polymer.Base.get(globalChannel.name, this) || {};
+                    Object.keys(data).forEach(function(key) {
                         // Specifying no value so it gets cleared.
                         this.set(channelName, key, undefined);
                     }.bind(this))
-                    globalChannel.data = {};
+                    Polymer.Base.set(globalChannel.name, {}, this);
 
                     // Remove the channel data from storage.
                     this.$.storage.remove(globalChannel.name);
@@ -120,7 +123,8 @@ var broker = window.Urth['urth-core-channel-broker'].getChannelBroker();
             get: function(channelName, key) {
                 var globalChannel = this._getGlobalChannel(channelName);
                 if (globalChannel){
-                    return key ? globalChannel.data[key] : globalChannel.data;
+                    var channelKey = globalChannel.name + (key ? '.' + key : '');
+                    return Polymer.Base.get(channelKey, this);
                 }
             },
 
@@ -202,13 +206,13 @@ var broker = window.Urth['urth-core-channel-broker'].getChannelBroker();
              * @return {Object} The data associated with the specified channel.
              */
             removeChannelElement: function(channelName, element) {
-                var channel = this._getGlobalChannel(channelName);
-                var data = channel ? channel.data : {};
+                var globalChannel = this._getGlobalChannel(channelName);
+                var data = globalChannel ? Polymer.Base.get(globalChannel.name, this) : {};
 
-                if (channel && element) {
-                    var index = channel.elements.indexOf(element);
+                if (globalChannel && element) {
+                    var index = globalChannel.elements.indexOf(element);
                     if (index !== -1) {
-                        channel.elements.splice(index, 1);
+                        globalChannel.elements.splice(index, 1);
                     }
                 }
 
@@ -224,8 +228,9 @@ var broker = window.Urth['urth-core-channel-broker'].getChannelBroker();
             save: function(channelName) {
                 var globalChannel = this._getGlobalChannel(channelName);
                 if (globalChannel) {
-                    if (globalChannel.data) {
-                        this.$.storage.set(globalChannel.name, globalChannel.data);
+                    var data = Polymer.Base.get(globalChannel.name, this);
+                    if (data) {
+                        this.$.storage.set(globalChannel.name, data);
                     } else {
                         this.$.storage.remove(globalChannel.name);
                     }
@@ -243,31 +248,78 @@ var broker = window.Urth['urth-core-channel-broker'].getChannelBroker();
              * @param {String} channelName The name of the channel.
              * @param {String} key The key to be associated with the value.
              * @param {Object} value The value to set.
+             * @param {Object} options Additional options. Currently
+             * only `oldValue` is supported. If not specified, the current value
+             * will be retrieved with the `get` method.
              */
-            set: function(channelName, key, value) {
+            set: function(channelName, key, value, options) {
                 var globalChannel = this._getOrCreateGlobalChannel(channelName);
-                if (!globalChannel) {
+                if (!key || !globalChannel) {
                     return;
                 }
                 channelName = globalChannel.name;
-                var oldVal = globalChannel && key ? this.get(channelName, key) : undefined;
 
-                if (key && globalChannel && oldVal !== value) {
-                    // 'undefined' value results in a delete of the key.
-                    if (typeof value === 'undefined') {
-                        globalChannel.data[key] = null;
-                        delete globalChannel.data[key];
-                    } else {
-                        globalChannel.data[key] = value;
+                // Retrieve the current (old) value unless an old value was passed in.
+                // Note, it could be specified but the value is undefined which
+                // is valid.
+                //
+                // The `set` method basically gets invoked in one of two ways:
+                //    1. Directly through broker or channel API. In this case if
+                //       options is not specified then the old value should be
+                //       retrievable through the `get` method.
+                //    2. Automatically by `_propertyChanged` on `urth-core-bind`.
+                //       In this case the Polymer framework will pass the old
+                //       value and it will be in the options argument. This is
+                //       good because invoking `get` for this situation would
+                //       return the new value instead of the old value due to
+                //       Polymer already having set it.
+                var oldVal = options && options.hasOwnProperty('oldValue') ?
+                        options.oldValue : this.get(channelName, key);
+
+                // Use the JSON value saved from a previous `set` invocation to
+                // determine if this `set` value has already been saved. If it
+                // hasn't or the value has changed, need to process it. Either
+                // way, the value of `oldVal` is used instead since it properly
+                // handles paths (ie. myarray.#0.value)
+                if (globalChannel.data[key] !== JSON.stringify(value)) {
+                    var rootKey = key,
+                        rootNewVal = value,
+                        rootOldVal = oldVal,
+                        dotIndex = key.indexOf('.'),
+                        rootInfo;
+
+                    Polymer.Base.set(channelName + '.' + key, value, this);
+                    // Store the JSON version of the value for later comparison
+                    // to determine if it has changed. Although doing this
+                    // potentially has some issues around object property
+                    // ordering, it should be sufficient for preventing looping.
+                    globalChannel.data[key] = value ?
+                            JSON.stringify(value) : value;
+
+                    // If the key that was modified is a path (ie. myarray.#0.prop)
+                    // then send information about the root of the path to the
+                    // kernel and listening elements.
+                    if (dotIndex >= 0) {
+                        rootKey = key.slice(0, dotIndex);
+                        rootNewVal = this.get(channelName, rootKey);
+                        rootOldVal = JSON.parse(globalChannel.data[rootKey]);
+                        rootInfo = {
+                            key: rootKey,
+                            oldValue: rootOldVal,
+                            value: rootNewVal
+                        };
+                        globalChannel.data[rootKey] = rootNewVal ?
+                                JSON.stringify(rootNewVal) : rootNewVal;
                     }
 
-                    this._sendItem(key, value, oldVal, channelName);
+                    this._sendItem(rootKey, rootNewVal, rootOldVal, channelName);
 
                     globalChannel.elements.forEach(function(channelElement) {
                         channelElement.fire('urth-channel-data-update', {
                             key: key,
                             oldValue: oldVal,
-                            value: value
+                            value: value,
+                            root: rootInfo
                         });
                     }.bind(this));
                 }
@@ -276,10 +328,8 @@ var broker = window.Urth['urth-core-channel-broker'].getChannelBroker();
             _createGlobalChannel: function(channelName) {
                 if (!_globalChannels[channelName]) {
                     _globalChannels[channelName] = initChannel(channelName);
-                    if (!_globalChannels[channelName].initialized) {
-                        this.reload(channelName);
-                        _globalChannels[channelName].initialized = true;
-                    }
+                    Polymer.Base.set(channelName, {}, this);
+                    this.reload(channelName);
                     console.debug('urth-core-channel-broker _createGlobalChannel: ' +
                         'created new channel', channelName, '.'
                     );

--- a/elements/urth-core-channel/urth-core-channel-item.html
+++ b/elements/urth-core-channel/urth-core-channel-item.html
@@ -45,8 +45,6 @@ Example: Initialize channel data.
             ],
 
             _notifyItemChange: function() {
-                var value = this.value;
-
                 if (!this.key) {
                     return;
                 }

--- a/elements/urth-core-channel/urth-core-channel.html
+++ b/elements/urth-core-channel/urth-core-channel.html
@@ -234,9 +234,12 @@ dataChannel.set('user', 'Luke');
              * @method set
              * @param {String} key The key to be associated with the value.
              * @param {Object} value The value to set.
+             * @param {Object} options Additional options. Currently
+             * only `oldValue` is supported. If not specified, the current value
+             * will be retrieved with the `get` method.
              */
-            set: function(key, value) {
-                this._broker.set(this.name, key, value);
+            set: function(key, value, options) {
+                this._broker.set(this.name, key, value, options);
             },
 
             /**
@@ -331,7 +334,7 @@ dataChannel.set('user', 'Luke');
                         Object.keys(oldData).filter(function(key) {
                             return typeof newData[key] === 'undefined';
                         }).forEach(function(key) {
-                            this._updateRegistered(key, undefined, undefined, false);
+                            this._updateRegistered(key, undefined, oldData[key], false);
                         }.bind(this));
                     }
 
@@ -350,25 +353,47 @@ dataChannel.set('user', 'Luke');
             _updateData: function(item) {
                 if (item && item.detail && item.detail.key) {
                     this._updateRegistered(item.detail.key,
-                        item.detail.value, item.detail.oldValue, true);
+                        item.detail.value, item.detail.oldValue, true,
+                        item.detail.root);
                 }
             },
 
-            _updateRegistered: function(key, newVal, oldVal, updateWatchers) {
-                if (key) {
+            _updateRegistered: function(key, newVal, oldVal, updateWatchers, root) {
+                if (key && oldVal !== newVal) {
                     if (this.registeredElements) {
                         this.registeredElements.forEach(function(element) {
-                            if (this !== element || element[key] !== newVal) {
-                                element[key] = newVal;
+                            if (this !== element) {
+                                // $$ is a function that is added to Polymer
+                                // elements. If the element is a Polymer element
+                                // then use the `set` API which handles paths
+                                // correctly, otherwise have to resort to just
+                                // setting a value for the property directly on
+                                // the element.
+                                typeof element.$$ === 'function' ?
+                                        element.set(key, newVal) :
+                                        element[key] = newVal;
                             }
                         }.bind(this));
                     }
 
-                    if (updateWatchers && this.watchers && Array.isArray(this.watchers[key])) {
-                        this.watchers[key].forEach(function(handler) {
-                            handler(key, oldVal, newVal);
-                        });
+                    if (updateWatchers) {
+                        this._updateWatchers(key, newVal, oldVal);
+
+                        // If this was a complex path update (ie. key = myprop.#0.myvar),
+                        // then send the watchers on the root the updated info.
+                        if (root && root.key) {
+                            this._updateWatchers(root.key, root.value, root.oldValue);
+                        }
                     }
+
+                }
+            },
+
+            _updateWatchers: function(key, newVal, oldVal) {
+                if (this.watchers && Array.isArray(this.watchers[key])) {
+                    this.watchers[key].forEach(function(handler) {
+                        handler(key, oldVal, newVal);
+                    });
                 }
             }
         });

--- a/etc/notebooks/tests/urth-core-bind.ipynb
+++ b/etc/notebooks/tests/urth-core-bind.ipynb
@@ -25,6 +25,65 @@
     "    <paper-input id='titleInput' label='Title' value='{{title}}'></paper-input>\n",
     "</template>"
    ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Validate that changes made to array items properly flow between cells\n",
+    "\n",
+    "When input is updated in the second cell, the first cell content should update."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "%%html\n",
+    "<!-- Prepopulate the channel with data -->\n",
+    "<urth-core-channel name='arraybind'>\n",
+    "    <urth-core-channel-item key='people' value='[{\"name\": \"luke\"}]'></urth-core-channel-item>\n",
+    "</urth-core-channel>\n",
+    "\n",
+    "<template id='tb' is='urth-core-bind' channel='arraybind'>\n",
+    "  First template\n",
+    "  <template id='t1' is='dom-repeat' items='{{people}}'>\n",
+    "    <div>\n",
+    "      <input id='t1Person' value='{{item.name::input}}'></input>\n",
+    "    </div>\n",
+    "  </template>\n",
+    "</template>"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "%%html\n",
+    "<template id='tc' is='urth-core-bind' channel='arraybind'>\n",
+    "  Second template\n",
+    "  <template id='t2' is='dom-repeat' items='{{people}}'>\n",
+    "    <div>\n",
+    "      <input id='t2Person' value='{{item.name::input}}'></input>\n",
+    "    </div>\n",
+    "  </template>\n",
+    "\n",
+    "  Third template\n",
+    "  <template id='t3' is='dom-repeat' items='{{people}}'>\n",
+    "    <div>\n",
+    "      <span id='t3Person'>{{item.name::input}}</span>\n",
+    "    </div>\n",
+    "  </template>\n",
+    "</template>"
+   ]
   }
  ],
  "metadata": {

--- a/system-test/urth-core-bind-specs.js
+++ b/system-test/urth-core-bind-specs.js
@@ -9,7 +9,7 @@ describe('Urth Core Bind', function() {
 
     boilerplate.setup(this.title, '/notebooks/tests/urth-core-bind.ipynb');
 
-    it('should run all cells and wait for dependency to load', function(done) {
+    it('should wait for dependency to load', function(done) {
         // Using a random number to protect against the possibility of a previous
         // test run value having been persisted.
         var inputString = 'Hello ' + Math.random();
@@ -21,6 +21,22 @@ describe('Urth Core Bind', function() {
             .keys(inputString)
             .elementById('titleSpan')
             .text().should.eventually.include(inputString)
+            .nodeify(done);
+    });
+
+    it('should synchronize array item changes cross cell on the same channel', function(done) {
+        // Using a random number to protect against the possibility of a previous
+        // test run value having been persisted.
+        var inputString = 'Hello ' + Math.random();
+
+        boilerplate.browser
+            .waitForElementById('t2Person', wd.asserters.isDisplayed, 10000)
+            .elementById('t2Person')
+            .type(inputString)
+            .elementById('t3Person')
+            .text().should.eventually.include(inputString)
+            .elementById('t1Person')
+            .getValue().should.eventually.include(inputString)
             .nodeify(done);
     });
 });


### PR DESCRIPTION
Fixes a bug where the channel element did not properly handle path changes (ie. `myarray.#0.myvar`) that happen when modifying an element of an array or a property of an object.

Fixes #230
