### PR TITLE
Fix urth-core-bind for Polymer 1.3 changes.

### DIFF
--- a/elements/urth-core-bind/urth-core-bind.html
+++ b/elements/urth-core-bind/urth-core-bind.html
@@ -66,7 +66,9 @@
                  */
                 noWait: {
                     type: Boolean,
-                    value: false,
+                    // Not defining a default value because Polymer > v1.3 does
+                    // not set the value specified here anyway since this
+                    // element extends `template` and does its own stamping.
                     reflectToAttribute: true
                 },
                 /**
@@ -74,11 +76,18 @@
                  */
                 channel: {
                     type: String,
-                    value: 'default',
+                    // Not defining a default value since `urth-core-channel`
+                    // defines it and Polymer > v1.3 does not set the value
+                    // specified here anyway since this element extends
+                    // `template` and does its own stamping.
                     observer: '_onChannelChange'
                 }
             },
             behaviors: [Urth.DomBindBehavior],
+
+            created: function() {
+                this._createChannel();
+            },
 
             detached: function() {
                 // Unregister from the channel when element is detached.
@@ -118,11 +127,7 @@
             },
 
             _onChannelChange: function(newVal, oldVal) {
-                if (!this.channelElement) {
-                    this._createChannel();
-                } else {
-                    this.channelElement.setAttribute('name', newVal);
-                }
+                this.channelElement.setAttribute('name', newVal);
             },
 
             _propertyChanged: function(property, newVal, oldVal) {


### PR DESCRIPTION
Polymer 1.3 introduced some changes which broke `urth-core-bind`. That element extends `template` and also makes use of `dom-bind` from Polymer to customize the stamping of the template. Something in Polymer 1.3 (I think commit Polymer/polymer@d99e6939d6ec18804cd733dd2e781bafd300814a) now prevents the default values specified in the properties object from being set and also prevents the initial invocation of the observer which we were counting on to setup the channel.

I've made changes in this commit to basically take away the default values since they aren't really necessary and don't do anything in 1.3 and ensured the code works for both 1.2.4 and 1.3 versions of Polymer.
