### PR TITLE
Fixed problem with urth-core-function tests in safari

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -188,9 +188,10 @@ sdist: dist
 
 test: test-js test-py test-scala
 
+test-js:BROWSER?=chrome
 test-js: | $(URTH_COMP_LINKS)
 	@echo 'Running web component tests...'
-	@npm run test
+	@npm run test -- --local $(BROWSER)
 
 test-js-remote: | $(URTH_COMP_LINKS)
 ifdef SAUCE_USER_NAME
@@ -231,8 +232,9 @@ else
 			sbt test'
 endif
 
+testdev:BROWSER?=chrome
 testdev: | $(URTH_COMP_LINKS)
-	@npm run test -- -p
+	@npm run test -- -p --local $(BROWSER)
 
 install: CMD?=exit
 install: SERVER_NAME?=urth_widgets_install_validation

--- a/elements/urth-core-function/test/urth-core-function.html
+++ b/elements/urth-core-function/test/urth-core-function.html
@@ -172,7 +172,6 @@
                 var _onParameterChange = sinon.spy(fElmt, "_onParameterChange");
 
                 fElmt.set("args.x", [1,2,3])
-
                 assert(_syncParamAttributes.calledOnce, "_syncParamAttributes was called " + _syncParamAttributes.callCount);
                 assert(_syncParamAttributes.calledWith({
                     x: [1,2,3]
@@ -188,12 +187,25 @@
 
                 //NOTE: Polymer sends 2 events when arrays are spliced
                 assert(_syncParamAttributes.calledTwice, "_syncParamAttributes was called " + _syncParamAttributes.callCount);
-                assert(_syncParamAttributes.calledWith({
-                    x: [1,2,3,4]
-                }), "_syncParamAttributes called with wrong arguments");
+
+                //NOTE: Safari exposes an issue with "push" whereas the property "x" has more Object properties than
+                // a simple array and thuse fails the deep comparison. Have to compare individual items
+                var expectedArgs = _syncParamAttributes.getCall(0).args;
+                expect(expectedArgs[0].x[0]).to.equal(1);
+                expect(expectedArgs[0].x[1]).to.equal(2);
+                expect(expectedArgs[0].x[2]).to.equal(3);
+                expect(expectedArgs[0].x[3]).to.equal(4);
 
                 assert(_onParameterChange.calledTwice, "_onParameterChange was called " + _onParameterChange.callCount);
-                assert(_onParameterChange.calledWith("x", [1,2,3,4]), "_onParameterChange called with wrong arguments");
+
+                //NOTE: After a push, polymer records the event in a "splices" member in the Array. This breaks deep equality
+                //Have to compare individual items
+                expectedArgs = _onParameterChange.getCall(0).args;
+                expect(expectedArgs[0]).to.equal("x");
+                expect(expectedArgs[1][0]).to.equal(1);
+                expect(expectedArgs[1][1]).to.equal(2);
+                expect(expectedArgs[1][2]).to.equal(3);
+                expect(expectedArgs[1][3]).to.equal(4);
 
             });
 
@@ -1037,7 +1049,16 @@
                 fElmt.push("argX", 4);
 
                 assert(_onParameterChange.calledOnce, "_onParameterChange was called " + _onParameterChange.callCount);
-                assert(_onParameterChange.calledWith("x", [1,2,3,4]), "_onParameterChange called with wrong arguments");
+
+                //NOTE: Safari exposes an issue with "push" whereas the property "x" has more Object properties than
+                // a simple array and thuse fails the deep comparison. Have to compare individual items
+                var expectedArgs =  _onParameterChange.getCall(0).args;
+                expect(expectedArgs[0]).to.equal("x")
+
+                expect(expectedArgs[1][0]).to.equal(1)
+                expect(expectedArgs[1][1]).to.equal(2)
+                expect(expectedArgs[1][2]).to.equal(3)
+                expect(expectedArgs[1][3]).to.equal(4)
 
             });
 


### PR DESCRIPTION
This PR re-enables the 2 tests for urth-core-function that were failing in Safari.
