### PR TITLE
Fixes to better control version of polymer at runtime

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -113,7 +113,7 @@ dist/urth/widgets/ext/notebook/urth_components: bower_components ${shell find el
 	@mkdir -p dist/urth/widgets/ext/notebook/urth_components
 	@cp -RL bower_components/* dist/urth/widgets/ext/notebook/urth_components/.
 
-dist/urth/widgets/ext/notebook: dist/urth/widgets/ext/notebook/urth_components dist/urth/widgets/ext/notebook/js dist/urth/widgets/ext/notebook/elements
+dist/urth/widgets/ext/notebook: dist/urth/widgets/ext/notebook/bower.json dist/urth/widgets/ext/notebook/urth_components dist/urth/widgets/ext/notebook/js dist/urth/widgets/ext/notebook/elements
 
 dist/urth/widgets/ext: ${shell find nb-extension/python/urth/widgets/ext}
 	@echo 'Moving frontend extension code'
@@ -139,6 +139,10 @@ else
 			sbt package && \
 			cp target/scala-2.10/urth-widgets*.jar /src/dist/urth/widgets/ext/notebook/urth-widgets.jar'
 endif
+
+dist/urth/widgets/ext/notebook/bower.json: bower.json
+	@mkdir -p dist/urth/widgets/ext/notebook
+	@cp bower.json dist/urth/widgets/ext/notebook/bower.json
 
 dist/docs: dist/docs/bower_components dist/docs/site dist/docs/site/generated_docs.json
 

--- a/bower.json
+++ b/bower.json
@@ -19,7 +19,7 @@
   ],
   "private": true,
   "dependencies": {
-    "polymer": "Polymer/polymer#^1.2.4",
+    "polymer": "Polymer/polymer#>=1.2.4 <1.4.0",
     "webcomponentsjs": "^0.7.2"
   },
   "devDependencies": {


### PR DESCRIPTION
These changes allow use to peg the versions of Polymer (an any other dependency) used at runtime. It basically allows us to have more control of the runtime libraries even after the user imports more elements.
