### PR TITLE
Load DeclWidgetModel without registry

### DIFF
--- a/elements/urth-core-behaviors/jupyter-widget-behavior.html
+++ b/elements/urth-core-behaviors/jupyter-widget-behavior.html
@@ -50,8 +50,7 @@ This behavior is used to encapsulate some of the services needed for ipywidgets.
                         model_module: 'nbextensions/urth_widgets/js/widgets/DeclWidgetModel',
                         model_name: 'DeclWidgetModel',
                         widget_class: this.kernelClass
-                    },
-                    {}
+                    }
                 ).then(function(model) {
                         console.log('Model creation successful!', model);
                         this.__modelChangeCallback = this._onModelChange.bind(this);

--- a/nb-extension/js/init/init.js
+++ b/nb-extension/js/init/init.js
@@ -142,8 +142,6 @@ define([
      * @param  {Object} config - configuration; see following entries for more information
      * @param  {Object} config.namespace - Jupyter Notebook namespace object (or shim)
      * @param  {Object} config.events - Notebook events object
-     * @param  {Object} config.WidgetManager - widget manager class
-     * @param  {Object} config.WidgetModel - widget model class
      * @return {Promise} resolved when widgets have been fully initialized
      */
     return function(config) {

--- a/nb-extension/js/main.js
+++ b/nb-extension/js/main.js
@@ -5,10 +5,8 @@
 define([
     'base/js/namespace',
     'base/js/events',
-    'nbextensions/widgets/widgets/js/init',
-    'nbextensions/widgets/widgets/js/widget',
     './init/init'
-], function(Jupyter, events, widgetManager, ipywidget, init) {
+], function(Jupyter, events, init) {
     'use strict';
 
     // Some versions of IE do not have window.console defined. Some versions
@@ -22,9 +20,7 @@ define([
     
     init({
         namespace: Jupyter,
-        events: events,
-        WidgetManager: widgetManager.WidgetManager,
-        WidgetModel: ipywidget.WidgetModel
+        events: events
     });
 
     return {

--- a/nb-extension/js/widgets/DeclWidgetModel.js
+++ b/nb-extension/js/widgets/DeclWidgetModel.js
@@ -33,7 +33,7 @@ define(["nbextensions/widgets/widgets/js/widget"], function(Widget) {
             this.comm.send(data, callbacks);
         }
     });
-
+    
     return {
         DeclWidgetModel: DeclWidgetModel
     };


### PR DESCRIPTION
Ref #275 

This is what I created before seeing @lbustelo's competing PR at #278. This specifically sets up the init & model JS code under the `jupyter-decl-widgets` package name (but unfortunately requires the use of `requirejs()` -- it works, but is it correct to do so?).

This PR works with the following patch in `jupyter-incubator/dashboards_server`:

``` diff
diff --git a/public/js/dashboard.js b/public/js/dashboard.js
index 0ba8e56..6a5be34 100644
--- a/public/js/dashboard.js
+++ b/public/js/dashboard.js
@@ -149,19 +149,31 @@ requirejs([
             var path = a.pathname;
             var sep = path[path.length-1] === '/' ? '' : '/';
             require.config({
-                paths: {
-                    'urth_widgets': a.protocol + '//' + a.host + path + sep + 'urth_widgets'
+                packages: [
+                    {
+                        name: 'jupyter-decl-widgets',
+                        location: path + sep + 'urth_widgets',
+                        main: 'js/init/init'
                     }
+                ]
             });

-            require(['urth_widgets/js/init/init'], function(DeclWidgets) {
+            require(['jupyter-decl-widgets'], function(DeclWidgets) {
                 // initialize Declarative Widgets
-                DeclWidgets({
+                var dwOpts = {
                         namespace: window.Jupyter,
                         events: window.Jupyter.notebook.events,
                         WidgetManager: WidgetManager,
                         WidgetModel: Widgets.WidgetModel
-                }).then(deferred.resolve);
+                    };
+                var promise;
+                if (DeclWidgets.init) {
+                    promise = DeclWidgets.init(dwOpts);
+                } else {
+                    // older API -- backwards compatibility for declwidgets 0.4.x and lower
+                    promise = DeclWidgets(dwOpts);
+                }
+                promise.then(deferred.resolve);
             });
         } else {
             console.log('Declarative Widgets not supported ("urth_components" directory not found)');
```
