### PR TITLE
Override _finishRegisterFeatures to fix Polymer 1.4 break.

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -19,7 +19,7 @@
   ],
   "private": true,
   "dependencies": {
-    "polymer": "Polymer/polymer#>=1.2.4 <1.4.0",
+    "polymer": "Polymer/polymer#>=1.2.4 <1.4.1",
     "webcomponentsjs": "^0.7.2"
   },
   "devDependencies": {

--- a/elements/urth-core-bind/dom-bind-behavior.html
+++ b/elements/urth-core-bind/dom-bind-behavior.html
@@ -36,7 +36,13 @@
             // have resolved
             var self = this;
             Polymer.RenderStatus.whenReady(function() {
-                 self._markImportsReady();
+                if (document.readyState == 'loading') {
+                    document.addEventListener('DOMContentLoaded', function() {
+                        self._markImportsReady();
+                    });
+                } else {
+                    self._markImportsReady();
+                }
             });
         },
 
@@ -54,6 +60,17 @@
         _registerFeatures: function() {
             this._prepConstructor();
         },
+
+        // BEGIN URTH_CUSTOM
+        _finishRegisterFeatures: function() {
+            // Polmer 1.4 added lazy registration. That feature split some of
+            // the functionality in `_registerFeatures` out into a method named
+            // `_finishRegisterFeatures`. Since this behavior does its own
+            // initialization, need to override this method with empty
+            // functionality to prevent errors that can occur with template
+            // property initialization.
+        },
+        // END URTH_CUSTOM
 
         _insertChildren: function() {
             var parentDom = Polymer.dom(Polymer.dom(this).parentNode);


### PR DESCRIPTION
1. Resync our `dom-bind-behavior` with latest `dom-bind` code.
2. Override `_finishRegisterFeatures` to allow `urth-core-bind` to work on Polymer 1.4+.
3. Update bower.json to allow Polymer 1.4.0.

Fixes #283 
