### PR TITLE
Adds urth-viz-ipywidget element to integrate with ipywidgets [#302]

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -59,7 +59,9 @@ dev_image:
 		apt-get install --yes nodejs npm && \
 		ln -s /usr/bin/nodejs /usr/bin/node && \
 		npm install -g bower && \
-		Rscript /src-kernel-r/install.r'
+		Rscript /src-kernel-r/install.r && \
+		mkdir -p /home/jovyan/.local/share/jupyter/nbextensions && \
+		chown -R jovyan:users /home/jovyan/.local/share/jupyter/nbextensions'
 	@docker commit bower-build $(REPO)
 	@-docker rm -f bower-build
 

--- a/elements/urth-core-behaviors/jupyter-kernel-observer.html
+++ b/elements/urth-core-behaviors/jupyter-kernel-observer.html
@@ -25,13 +25,15 @@ This behavior is used to implement handlers to kernel events
                 }
                 console.debug("Registering onKernelReady for Kernel Ready messages.")
 
-                this.__kernelReadyCallback = this.onKernelReady.bind(this);
+                this.__kernelReadyCallback = function(){
+                    this.onKernelReady(Urth.kernel);
+                }.bind(this);
                 Urth.events.on(
                     'kernel_ready.Kernel', this.__kernelReadyCallback
                 );
 
                 if (Urth.kernel && Urth.kernel.is_connected()) {
-                  this.onKernelReady();
+                  this.onKernelReady(Urth.kernel);
                 }
             },
 
@@ -50,8 +52,10 @@ This behavior is used to implement handlers to kernel events
              * `onLoad` of the page if there is already a ready kernel.
              *
              * @method onKerneReady
+             * @param kernel - the kernel object
              */
-            onKernelReady: function(){}
+            onKernelReady: function(kernel){}
+
 
         };
     })();

--- a/elements/urth-viz-ipywidget/bower.json
+++ b/elements/urth-viz-ipywidget/bower.json
@@ -1,0 +1,26 @@
+{
+  "name": "urth-viz-ipywidget",
+  "version": "0.0.1",
+  "authors": [
+    "Jupyter Community"
+  ],
+  "description": "Client side interface to IPywidgets.",
+  "main": "urth-viz-ipywidget.html",
+  "keywords": [
+    "urth",
+    "web-components",
+    "jupyter",
+    "ipywidgets"
+  ],
+  "ignore": [
+    "**/.*",
+    "node_modules",
+    "bower_components",
+    "test",
+    "tests"
+  ],
+  "dependencies": {
+    "polymer": "Polymer/polymer#^1.2.4"
+  },
+  "private": true
+}

--- a/elements/urth-viz-ipywidget/test/urth-viz-ipywidget.html
+++ b/elements/urth-viz-ipywidget/test/urth-viz-ipywidget.html
@@ -1,0 +1,329 @@
+<!doctype html>
+<!--
+# Copyright (c) Jupyter Development Team.
+# Distributed under the terms of the Modified BSD License.
+-->
+<html>
+<head>
+    <meta charset="utf-8">
+    <!-- STEP 1: Provide a title for the test suite. -->
+    <title>urth-core-function tests</title>
+    <meta name='viewport' content='width=device-width, minimum-scale=1.0, initial-scale=1.0, user-scalable=yes'>
+
+    <!-- Need the web component polyfill for browsers without native support. -->
+    <script src='../../webcomponentsjs/webcomponents-lite.js'></script>
+
+    <!-- Load test framework and helpers. -->
+    <script src='../../web-component-tester/browser.js'></script>
+    <script src='../../test-fixture/test-fixture-mocha.js'></script>
+    <link rel='import' href='../../test-fixture/test-fixture.html'>
+
+    <!-- STEP 2: Import the element to test. -->
+    <link rel='import' href='../urth-viz-ipywidget.html'>
+
+</head>
+
+<body>
+
+    <!-- STEP 3: Setup document with DOM to test. Use test-fixture elements
+         to ease setup and cleanup of elements. -->
+    <test-fixture id='basic'>
+        <template>
+            <urth-viz-ipywidget ref="someWidget"></urth-viz-ipywidget>
+        </template>
+    </test-fixture>
+
+    <test-fixture id='attributes'>
+        <template>
+            <urth-viz-ipywidget ref="someWidget" trait-x="a" trait-y="b" trait-z="5" someotherattr="foo"></urth-viz-ipywidget>
+        </template>
+    </test-fixture>
+
+    <test-fixture id='properties'>
+        <template>
+            <urth-viz-ipywidget ref="someWidget" traits='{"x":"a","y":"b","z":5}' someotherattr="foo"></urth-viz-ipywidget>
+        </template>
+    </test-fixture>
+
+    <script>
+        var createModel;
+
+        // STEP 4: Define any globals needed by the test suite.
+        before(function() {
+            /*
+             * Non-lifecycle methods must be mocked on the prototype.
+             * Lifecycle methods(e.g. detached, ready) remain in the behavior, so they
+             * must be mocked there.
+             */
+            createModel = sinon.stub(Urth["urth-viz-ipywidget"].prototype, "createModel");
+            sinon.stub(Urth["urth-viz-ipywidget"].prototype, "displayErrorMessage");
+            sinon.stub(Urth.ExecutionCompleteBehavior, "ready");
+            sinon.stub(Urth.ExecutionCompleteBehavior, "detached");
+            sinon.stub(Urth["urth-viz-ipywidget"].prototype, "onKernelReady");
+        });
+
+        beforeEach(function(){
+            createModel.reset();
+        });
+
+        // STEP 5: Define suite(s) and tests.
+        describe('_onKernelInfo', function() {
+
+            it('should create model for python kernels', function () {
+                var fElmt = fixture('basic');
+
+                fElmt._onKernelInfo({ name: 'python_some_version'});
+
+                //another attribute set.
+                expect(createModel).to.have.been.calledOnce;
+            });
+
+            it('should not create model for non-python kernels', function () {
+                var fElmt = fixture('basic');
+
+                fElmt._onKernelInfo({ name: 'some_other_kernel'});
+
+                //another attribute set.
+                expect(createModel).to.have.not.been.called;
+            });
+        });
+
+        describe('_traitsFromAttributes', function() {
+            it('should return an object with traits based on attributes', function() {
+                var fElmt = fixture('attributes');
+                expect(fElmt._traitsFromAttributes()).to.eql({x:"a", y:"b", z:"5"});
+            });
+        });
+
+        describe('_syncTraitProperty', function() {
+            it('should update trait- properties', function() {
+                var fElmt = fixture('basic');
+
+                fElmt._setupTraitProperties({
+                    x: 0,
+                    y: 0,
+                    z: 0
+                });
+                fElmt._syncTraitProperty({x:1, y:"2", z:"3"});
+
+                expect(fElmt['traitX']).to.equal(1);
+                expect(fElmt['traitY']).to.equal("2");
+                expect(fElmt['traitZ']).to.equal("3");
+            });
+
+            it('should update only the trait- properties that exist in the signature', function() {
+                var fElmt = fixture('basic');
+
+                fElmt._setupTraitProperties({
+                    y: 0,
+                    z: 0
+                });
+                fElmt._syncTraitProperty({x:"1", y:"2", z:"3"});
+
+                expect(fElmt['traitX']).to.not.exist;
+                expect(fElmt['traitY']).to.equal("2");
+                expect(fElmt['traitZ']).to.equal("3");
+            });
+        });
+
+        describe('_isTraitAttribute', function() {
+            it('should return true if string starts with trait prefix', function() {
+                var fElmt = fixture('basic');
+                expect(fElmt._isTraitAttribute( "trait-x")).to.be.true;
+            });
+            it('should return false if string does not starts with trait prefix', function() {
+                var fElmt = fixture('basic');
+
+                expect(fElmt._isTraitAttribute( "trait-")).to.be.false;
+                expect(fElmt._isTraitAttribute( "another_property")).to.be.false;
+                expect(fElmt._isTraitAttribute( "anothertrait-")).to.be.false;
+                expect(fElmt._isTraitAttribute( "anothertraits-asdfa")).to.be.false;
+            });
+
+        });
+
+        describe('_setupTraitProperties', function() {
+            it('should set values to trait property', function() {
+                var fElmt = fixture('basic');
+
+                fElmt._setupTraitProperties({
+                    x: 1,
+                    y: 2,
+                    z: 'some val'
+                });
+
+                expect(fElmt.traits).to.eql({
+                    x: 1,
+                    y: 2,
+                    z: 'some val'
+                })
+
+                expect(fElmt.hasOwnProperty('traitX')).to.be.true;
+                expect(fElmt.hasOwnProperty('traitY')).to.be.true;
+                expect(fElmt.hasOwnProperty('traitZ')).to.be.true;
+
+                expect(fElmt.traitX).to.equal(1);
+                expect(fElmt.traitY).to.equal(2);
+                expect(fElmt.traitZ).to.equal('some val');
+            });
+
+            it('should not set default values to args property if empty signature', function() {
+                var fElmt = fixture('basic');
+
+                fElmt._setupTraitProperties({});
+
+                expect(fElmt.traits).to.eql({});
+
+                expect(fElmt.hasOwnProperty('traitsX')).to.be.false;
+                expect(fElmt.hasOwnProperty('traitsY')).to.be.false;
+                expect(fElmt.hasOwnProperty('traitsZ')).to.be.false;
+
+            });
+
+            it('should not set values to tratis property if the property already contains a value', function() {
+                var fElmt = fixture('properties');
+
+                fElmt._setupTraitProperties({
+                    x: 'another a',
+                    y: 'another b',
+                    z: 'another 5'
+                });
+
+                expect(fElmt.traits).to.eql({
+                    x: 'a',
+                    y: 'b',
+                    z: 5
+                })
+
+                expect(fElmt.hasOwnProperty('traitX')).to.be.true;
+                expect(fElmt.hasOwnProperty('traitY')).to.be.true;
+                expect(fElmt.hasOwnProperty('traitZ')).to.be.true;
+
+                expect(fElmt.traitX).to.equal('a');
+                expect(fElmt.traitY).to.equal('b');
+                expect(fElmt.traitZ).to.equal(5);
+            });
+
+
+            it('should set value of argName property if it is set in the args property from attributes at init', function() {
+                var fElmt = fixture('attributes');
+                fElmt._setupTraitProperties({
+                    x: 'another a',
+                    y: 'another b',
+                    z: 'another 5'
+                });
+
+                expect(fElmt.traits).to.eql({
+                    x: 'a',
+                    y: 'b',
+                    z: '5'
+                })
+
+                expect(fElmt.hasOwnProperty('traitX')).to.be.true;
+                expect(fElmt.hasOwnProperty('traitY')).to.be.true;
+                expect(fElmt.hasOwnProperty('traitZ')).to.be.true;
+
+                expect(fElmt.traitX).to.equal('a');
+                expect(fElmt.traitY).to.equal('b');
+                expect(fElmt.traitZ).to.equal('5');
+            });
+
+            it('should set values already present on the element\'s proto to traits property', function() {
+                var fElmt = fixture('basic');
+
+                fElmt.traitX = "pre existing value";
+
+                fElmt._setupTraitProperties({
+                    x: "some other value",
+                    y: 5,
+                    z: 'some val'
+                });
+
+                expect(fElmt.traits).to.eql({
+                    x: "pre existing value",
+                    y: 5,
+                    z: 'some val'
+                })
+
+                expect(fElmt.hasOwnProperty('traitX')).to.be.true;
+                expect(fElmt.hasOwnProperty('traitY')).to.be.true;
+                expect(fElmt.hasOwnProperty('traitZ')).to.be.true;
+
+                expect(fElmt.traitX).to.equal("pre existing value")
+                expect(fElmt.traitY).to.equal(5);
+                expect(fElmt.traitZ).to.equal('some val');
+            });
+
+            it('should set values to traits property if it is set to NaN', function() {
+                var fElmt = fixture('basic');
+
+                fElmt.traits.x = NaN;
+
+                fElmt._setupTraitProperties({
+                    x: 5
+                });
+
+                expect(fElmt.traits).to.eql({
+                    x: 5
+                })
+
+                expect(fElmt.hasOwnProperty('traitX')).to.be.true;
+
+                expect(fElmt.traitX).to.equal(5);
+            });
+
+            it('should set to values on property when they are either 0 or false', function() {
+                var fElmt = fixture('basic');
+
+                fElmt.traitX = 0;
+                fElmt.traitY = false;
+
+                fElmt._setupTraitProperties({
+                    x: 1,
+                    y: true
+                });
+
+                expect(fElmt.traits).to.eql({x: 0, y: false});
+
+                expect(fElmt.hasOwnProperty('traitX')).to.be.true;
+                expect(fElmt.hasOwnProperty('traitY')).to.be.true;
+
+                expect(fElmt.traitX).to.equal(0);
+                expect(fElmt.traitY).to.be.false;
+            });
+
+            it('should add new trait properties in the new call', function() {
+                var fElmt = fixture('basic');
+
+                fElmt._setupTraitProperties({
+                    x: 1
+                });
+
+                fElmt._setupTraitProperties({
+                    x: 1,
+                    y: 2
+                });
+
+                expect(fElmt.hasOwnProperty('traitX')).to.be.true;
+                expect(fElmt.hasOwnProperty('traitY')).to.be.true;
+            });
+
+            it('should remove an argument property if it is not in the new call', function(){
+                var fElmt = fixture('basic');
+
+                fElmt._setupTraitProperties({
+                    x: 1,
+                    y: 2
+                });
+
+                fElmt._setupTraitProperties({
+                    x: 1
+                });
+
+                expect(fElmt.hasOwnProperty('traitY')).to.be.false;
+            });
+
+        });
+    </script>
+</body>
+</html>

--- a/elements/urth-viz-ipywidget/urth-viz-ipywidget.html
+++ b/elements/urth-viz-ipywidget/urth-viz-ipywidget.html
@@ -35,8 +35,8 @@ names for these properties have the form `trait-<name of trait>`.
     (function(){
     'use strict';
 
-        var ParamAttrPattern = /^trait-(.+)/;
-        var ParamPropPathPattern = /^traits\.([^\.\n]+)\.?/;
+        var TraitAttrPattern = /^trait-(.+)/;
+        var TraitPropPathPattern = /^traits\.([^\.\n]+)\.?/;
 
         window.Urth = window.Urth || {};
 
@@ -61,6 +61,11 @@ names for these properties have the form `trait-<name of trait>`.
                     readOnly: true
                 },
 
+                widgetModel: {
+                    type: Object,
+                    readOnly: true
+                },
+
                 /**
                  * Object reflecting the current values of the traits of the
                  * widget. This property can be used for binding.
@@ -78,7 +83,9 @@ names for these properties have the form `trait-<name of trait>`.
             ],
 
             observers: [
-                '_onArgsPropertyChanged(traits.*)'
+                '_onTraitPropertyChanged(traits.*)',
+                '__setWidgetModel(modelId)',
+                '_onWidgetModelChange(widgetModel)'
             ],
 
             created: function(){
@@ -103,12 +110,13 @@ names for these properties have the form `trait-<name of trait>`.
 
                 if( !this.traits ){
                     //sync with the attributes
-                    this.traits = this._paramsFromAttributes();
+                    this.traits = this._traitsFromAttributes();
                 }
             },
 
             /*
-             * onModelReady is invoked when have created the model portion of the widget
+             * onModelReady is invoked when have created the model portion of the widget. Sending the
+             * kernel side the value of `ref`.
              */
             onModelReady: function(){
                 console.debug('urth-viz-ipywidget onModelReady');
@@ -121,65 +129,49 @@ names for these properties have the form `trait-<name of trait>`.
             },
 
 
-            onModelIdChange: function(newVal){
-                console.debug('urth-viz-ipywidget onModelIdChange', newVal);
+            onModelIdChange: function(modelid){
+                console.debug('urth-viz-ipywidget onModelIdChange', modelid);
                 console.debug('urth-viz-ipywidget rendering view');
 
-                //get the actual ipywidget model and render it
-                this.model.widget_manager.get_model(newVal).then(function(m){
-                    this._setModelId(newVal);
+                this._setModelId(modelid);
 
-                    //hook listener to model changes
-                    m.on('change', function(options){
-                        var changes = options.changed;
-                        Object.keys(changes).forEach(function(change){
-                            this.set( "traits."+change, changes[change]);
-                        }.bind(this));
-                    }.bind(this));
+                //set the widgetModel
 
+            },
 
-                    //get the traits to expose them as properties
-                    var traits = {};
-                    Object.keys(m.attributes).filter(function(attribute){
-                        return attribute.indexOf("_") != 0;
-                    }).forEach(function(attribute){
-                        traits[attribute] = m.attributes[attribute];
-                    })
-
-                    this._onSpecChange(traits);
-
-                    //create the view
-                    this.model.widget_manager.create_view(m).then( function(v){
-                        console.log( "Created ipywidget view", v);
-                        Polymer.dom(this.root).innerHTML = '';
-                        Polymer.dom(this.root).appendChild(v.el);
-                    }.bind(this))
+            /*
+             * This method is acting as a computed property method, but since there are Promises involve, we need
+             * to set it up using observers.
+             */
+            __setWidgetModel: function(modelid){
+                this.model.widget_manager.get_model(modelid).then(function(widgetmodel){
+                    this._setWidgetModel(widgetmodel);
                 }.bind(this));
             },
 
-            _onArgsPropertyChanged: function(rec){
+            _onTraitPropertyChanged: function(rec){
                 if(this._syncing)
                     return;
 
-                console.debug('urth-viz-ipywidget _onArgsChanged', rec);
+                console.debug('urth-viz-ipywidget _onTraitPropertyChanged', rec);
                 if( rec.path === 'traits' ){
                     //entire parameter map changed
-                    this._syncParamAttributes(rec.value);
-                    this._onParameterChange(rec.path, rec.value);
+                    this._syncTraitAttributes(rec.value);
+                    this._onTraitChange(rec.path, rec.value);
                 }
-                else if (ParamPropPathPattern.test(rec.path)){
+                else if (TraitPropPathPattern.test(rec.path)){
                     //a single parameter changed
-                    var matches = ParamPropPathPattern.exec(rec.path)
-                    var param =  matches.length === 2 ? matches[1] : undefined;
+                    var matches = TraitPropPathPattern.exec(rec.path)
+                    var trait =  matches.length === 2 ? matches[1] : undefined;
 
-                    if( param ){
-                        console.debug('urth-viz-ipywidget got change for param', param);
+                    if( trait ){
+                        console.debug('urth-viz-ipywidget got change for trait', trait);
                         //reflect on the attibutes
-                        var params = {};
-                        var newVal = rec.base[param];
-                        params[param] = newVal;
-                        this._syncParamAttributes(params);
-                        this._onParameterChange(param, newVal);
+                        var traits = {};
+                        var newVal = rec.base[trait];
+                        traits[trait] = newVal;
+                        this._syncTraitAttributes(traits);
+                        this._onTraitChange(trait, newVal);
 
                     }
                 }
@@ -189,15 +181,15 @@ names for these properties have the form `trait-<name of trait>`.
                 this.refresh();
             },
 
-            _syncParamAttributes: function( params ){
-                params = !params ? {} : params;
+            _syncTraitAttributes: function( traits ){
+                traits = !traits ? {} : traits;
                 this._syncing = true;
                 try {
-                    Object.keys(params).forEach(function (param) {
-                        var argPropName = this._toParamPropertyName(param);
+                    Object.keys(traits).forEach(function (trait) {
+                        var traitPropName = this._toTraitPropertyName(trait);
 
-                        if( this.hasOwnProperty(argPropName) ){
-                            this[argPropName] = params[param];
+                        if( this.hasOwnProperty(traitPropName) ){
+                            this[traitPropName] = traits[trait];
                         }
 
                     }.bind(this))
@@ -207,113 +199,104 @@ names for these properties have the form `trait-<name of trait>`.
                 }
             },
 
-            /**
-             * Builds the `args` section of the 'invoke' message by serializing each
-             * param as necessary.
-             */
-            _serializeParamsForSend: function(){
-                var serArgs = {};
-                Object.keys(this.args).filter(function(arg){
-                    //remove args that contain the default value.
-                    return this.spec[arg] && this.args[arg] !== this.spec[arg].value;
-                }.bind(this)).forEach(function(arg){
-                    var value = this.args[arg];
-                    serArgs[arg] = (typeof value == 'boolean') ? value : this.serialize(value);
-                }.bind(this));
-
-                return serArgs;
-            },
-
-            _isParameterAttribute: function(attr /*attribute or string*/){
+            _isTraitAttribute: function(attr /*attribute or string*/){
                 var attrName =  typeof attr === 'string' ? attr : attr.name;
-                return ParamAttrPattern.test(attrName);
+                return TraitAttrPattern.test(attrName);
             },
 
-            /**
-             * Returns false if paramValue is undefined, null and NaN.
-             *
-             * @method _isParameterUnset
-             * @param {*} paramValue Any value sent to test
-             * @return {boolean} true if considered unset
-             */
-            _isParameterUnset: function(paramValue){
+            _isUnset: function(value){
                 /*
                  * Testing undefined, null and NaN.
                  * From https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/NaN#Testing_against_NaN
                  * a valid test for NaN is to test inequality to itself.
                  */
-                return paramValue === undefined || paramValue == null || (paramValue !== paramValue);
+                return value === undefined || value == null || (value !== value);
             },
 
-            _toParamName: function(attr /*attribute or string*/){
+            _toTraitName: function(attr /*attribute or string*/){
                 var attrName =  typeof attr === 'string' ? attr : attr.name;
 
-                var matches = ParamAttrPattern.exec(attrName)
+                var matches = TraitAttrPattern.exec(attrName)
                 return matches && matches.length === 2 ? matches[1] : undefined;
             },
 
-            _toParamPropertyName: function(paramName){
-                return 'trait' + paramName[0].toUpperCase() + paramName.substring(1);
+            _toTraitPropertyName: function(traitName){
+                return 'trait' + traitName[0].toUpperCase() + traitName.substring(1);
             },
 
-            _toParamPropertyObserverName: function(paramName){
-                var paramPropName = this._toParamPropertyName(paramName);
-                return '_on'+paramPropName[0].toUpperCase() + paramPropName.substring(1)+'Change'
+            _toTraitPropertyObserverName: function(traitName){
+                var traitPropName = this._toTraitPropertyName(traitName);
+                return '_on'+traitPropName[0].toUpperCase() + traitPropName.substring(1)+'Change'
             },
 
-            _paramsFromAttributes: function(){
+            _traitsFromAttributes: function(){
                 var attrs = this.attributes,
                         params = {};
 
                 for (var i = 0; i < attrs.length; i++) {
                     var attr = attrs[i];
-                    if (this._isParameterAttribute(attr)) {
-                        params[this._toParamName(attr)] = attr.nodeValue;
+                    if (this._isTraitAttribute(attr)) {
+                        params[this._toTraitName(attr)] = attr.nodeValue;
                     }
                 }
 
                 return params;
             },
 
-            _onParameterChange: function( argName, argValue ){
-                console.debug("urth-viz-ipywidget _onParameterChange", argName, argValue);
+            _onTraitChange: function( argName, argValue ){
+                console.debug("urth-viz-ipywidget _onTraitChange", argName, argValue);
 
                 if( this.isConnected() ){
-                    this.model.widget_manager.get_model(this.modelId).then(function(m){
-                        m.set(argName, argValue);
-                        m.save_changes();
-                    }.bind(this));
+                    this.widgetModel.set(argName, argValue);
+                    this.widgetModel.save_changes();
                 }
             },
 
             /**
-             * This method handles changes to the spec of the widget. It will create a new property based on
+             * This method handles setup for the new ipywidget WidgetModel. It will create a new property based on
              * the name of the traits. These new properties will allow data binding and will be kept in sync with
              * the contents of the `traits` property.
              *
              */
-            _onSpecChange: function(sig){
-                console.debug('urth-viz-ipywidget _onSignatureChange got new signature', sig);
+            _onWidgetModelChange: function(){
+                console.debug('urth-viz-ipywidget _setupTraits got new signature', traits);
                 this._clearErrorMessages();
                 this.resetDynamicProperties();
 
-                var paramNames = Object.keys(sig);
+                //hook listener to model changes
+                this.widgetModel.on('change', function(options){
+                    var changes = options.changed;
+                    Object.keys(changes).forEach(function(change){
+                        this.set( "traits."+change, changes[change]);
+                    }.bind(this));
+                }.bind(this));
+
+
+                //get the traits to expose them as properties
+                var traits = {};
+                Object.keys(this.widgetModel.attributes).filter(function(attribute){
+                    return attribute.indexOf("_") != 0;
+                }).forEach(function(attribute){
+                    traits[attribute] = this.widgetModel.attributes[attribute];
+                }.bind(this));
+
+                var paramNames = Object.keys(traits);
                 if( paramNames.length > 0 ){
 
                     //create new properties based on signature
                     var paramProperties = {}
                     paramNames.forEach(function(param){
-                        var argPropName = this._toParamPropertyName(param);
-                        var argPropObserverName = this._toParamPropertyObserverName(param);
+                        var argPropName = this._toTraitPropertyName(param);
+                        var argPropObserverName = this._toTraitPropertyObserverName(param);
 
                         //create an observer
-                        this[argPropObserverName] = this._createArgChangeHandler(param);
+                        this[argPropObserverName] = this._createTraitChangeHandler(param);
 
                         paramProperties[argPropName] = {
                             notify: true,
                             reflectToAttribute: true,
                             observer: argPropObserverName,
-                            value: this[argPropName] !== undefined ? this[argPropName] : sig[param]
+                            value: this[argPropName] !== undefined ? this[argPropName] : traits[param]
                         }
 
                     }.bind(this));
@@ -324,8 +307,8 @@ names for these properties have the form `trait-<name of trait>`.
                     var paramsToSync = {};
 
                     paramNames.forEach(function(param){
-                        if(this._isParameterUnset(this.traits[param])){
-                            var propValue = paramProperties[this._toParamPropertyName(param)].value
+                        if(this._isUnset(this.traits[param])){
+                            var propValue = paramProperties[this._toTraitPropertyName(param)].value
                             if( propValue !== undefined ) {
                                 this.set('traits.' + param, propValue);
                             }
@@ -335,8 +318,25 @@ names for these properties have the form `trait-<name of trait>`.
                         }
                     }.bind(this));
 
-                    this._syncParamAttributes(paramsToSync);
+                    this._syncTraitAttributes(paramsToSync);
+
+                    //update the widgetmodel with what was set on init
+                    Object.keys(paramsToSync).forEach(function (trait) {
+                        this._onTraitChange(trait, paramsToSync[trait]);
+                    }.bind(this))
+
+                    //create the view
+                    this._createWidgetView();
+
                 }
+            },
+
+            _createWidgetView: function(){
+                this.model.widget_manager.create_view(this.widgetModel).then( function(v){
+                    console.log( "Created ipywidget view", v);
+                    Polymer.dom(this.root).innerHTML = ''; //clearing area first
+                    Polymer.dom(this.root).appendChild(v.el);
+                }.bind(this))
             },
 
             /**
@@ -350,7 +350,7 @@ names for these properties have the form `trait-<name of trait>`.
                 this.send({ "event": "sync" });
             },
 
-            _createArgChangeHandler: function(param){
+            _createTraitChangeHandler: function(param){
 
                 return function(newVal){
                     console.log('urth-viz-ipywidget handling change to', param);
@@ -361,7 +361,7 @@ names for these properties have the form `trait-<name of trait>`.
                     this._syncing = true;
                     try {
                         this.set("traits." + param, newVal); //keep the property updated
-                        this._onParameterChange(param, newVal);
+                        this._onTraitChange(param, newVal);
                     }
                     finally {
                         delete this._syncing;

--- a/elements/urth-viz-ipywidget/urth-viz-ipywidget.html
+++ b/elements/urth-viz-ipywidget/urth-viz-ipywidget.html
@@ -1,0 +1,374 @@
+<!--
+# Copyright (c) Jupyter Development Team.
+# Distributed under the terms of the Modified BSD License.
+-->
+<link rel="import" href="../polymer/polymer.html">
+<link rel="import" href="../urth-core-behaviors/jupyter-widget-behavior.html">
+<link rel='import' href='../urth-core-behaviors/dynamic-properties-behavior.html'>
+<link rel="import" href="../urth-core-behaviors/execution-complete-behavior.html">
+
+<!--
+Allows displaying and binding with ipywidgets. This element only works against a Python
+kernel that has ipywidgets 4.x installed.
+
+To use this element, first create an instance of an ipywidget and assign it to a
+variable name.
+
+```
+slider = IntSlider()
+```
+
+Then use this element to display and interact with the ipywidget by setting the `ref`
+property to the variable name
+
+```
+<urth-viz-ipywidgets ref='slider' trait-value='{{aVal}}'></urth-viz-ipywidgets>
+```
+
+Traits for the ipywidgets are made available through the element as bind-able properties. The
+names for these properties have the form `trait-<name of trait>`.
+
+@group Urth Viz
+@element urth-viz-ipywidgets
+-->
+<script>
+    (function(){
+    'use strict';
+
+        var ParamAttrPattern = /^trait-(.+)/;
+        var ParamPropPathPattern = /^traits\.([^\.\n]+)\.?/;
+
+        window.Urth = window.Urth || {};
+
+        window.Urth['urth-viz-ipywidget'] = Polymer({
+            is: 'urth-viz-ipywidget',
+            properties: {
+
+                /**
+                 * Name of the widget to proxy. Must be a widget that is
+                 * defined in the kernel.
+                 */
+                ref: {
+                    type: String,
+                    value: ''
+                },
+
+                /**
+                 * The id of the ipywidget model.
+                 */
+                modelId: {
+                    type: String,
+                    readOnly: true
+                },
+
+                /**
+                 * Object reflecting the current values of the traits of the
+                 * widget. This property can be used for binding.
+                 */
+                traits: {
+                    type: Object,
+                    notify: true
+                }
+            },
+
+            behaviors: [
+                Urth.JupyterWidgetBehavior,
+                Urth.ExecutionCompleteBehavior,
+                Urth.DynamicPropertiesBehavior
+            ],
+
+            observers: [
+                '_onArgsPropertyChanged(traits.*)'
+            ],
+
+            created: function(){
+                console.debug('urth-viz-ipywidget created', arguments);
+
+                //only operate if the kernel is python
+                Urth.kernel.get_info(function(info){
+
+                    if(info.name.indexOf('python') == 0 ) {
+                        this.createModel('urth.widgets.widget_ipw_proxy.IpywProxy');
+                    }
+                    else{
+                        //not supported on any other kernels
+                        this.displayErrorMessage('Unsupported kernel. This element only supports Python.');
+                    }
+                }.bind(this))
+
+            },
+
+            ready: function() {
+                console.debug('urth-viz-ipywidget ready');
+
+                if( !this.traits ){
+                    //sync with the attributes
+                    this.traits = this._paramsFromAttributes();
+                }
+            },
+
+            /*
+             * onModelReady is invoked when have created the model portion of the widget
+             */
+            onModelReady: function(){
+                console.debug('urth-viz-ipywidget onModelReady');
+
+                var syncData = {
+                    widget_name: this.ref
+                }
+                console.debug('urth-viz-ipywidget sending initial sync', syncData);
+                this.sync(syncData);
+            },
+
+
+            onModelIdChange: function(newVal){
+                console.debug('urth-viz-ipywidget onModelIdChange', newVal);
+                console.debug('urth-viz-ipywidget rendering view');
+
+                //get the actual ipywidget model and render it
+                this.model.widget_manager.get_model(newVal).then(function(m){
+                    this._setModelId(newVal);
+
+                    //hook listener to model changes
+                    m.on('change', function(options){
+                        var changes = options.changed;
+                        Object.keys(changes).forEach(function(change){
+                            this.set( "traits."+change, changes[change]);
+                        }.bind(this));
+                    }.bind(this));
+
+
+                    //get the traits to expose them as properties
+                    var traits = {};
+                    Object.keys(m.attributes).filter(function(attribute){
+                        return attribute.indexOf("_") != 0;
+                    }).forEach(function(attribute){
+                        traits[attribute] = m.attributes[attribute];
+                    })
+
+                    this._onSpecChange(traits);
+
+                    //create the view
+                    this.model.widget_manager.create_view(m).then( function(v){
+                        console.log( "Created ipywidget view", v);
+                        Polymer.dom(this.root).innerHTML = '';
+                        Polymer.dom(this.root).appendChild(v.el);
+                    }.bind(this))
+                }.bind(this));
+            },
+
+            _onArgsPropertyChanged: function(rec){
+                if(this._syncing)
+                    return;
+
+                console.debug('urth-viz-ipywidget _onArgsChanged', rec);
+                if( rec.path === 'traits' ){
+                    //entire parameter map changed
+                    this._syncParamAttributes(rec.value);
+                    this._onParameterChange(rec.path, rec.value);
+                }
+                else if (ParamPropPathPattern.test(rec.path)){
+                    //a single parameter changed
+                    var matches = ParamPropPathPattern.exec(rec.path)
+                    var param =  matches.length === 2 ? matches[1] : undefined;
+
+                    if( param ){
+                        console.debug('urth-viz-ipywidget got change for param', param);
+                        //reflect on the attibutes
+                        var params = {};
+                        var newVal = rec.base[param];
+                        params[param] = newVal;
+                        this._syncParamAttributes(params);
+                        this._onParameterChange(param, newVal);
+
+                    }
+                }
+            },
+
+            _onExecutionComplete: function(){
+                this.refresh();
+            },
+
+            _syncParamAttributes: function( params ){
+                params = !params ? {} : params;
+                this._syncing = true;
+                try {
+                    Object.keys(params).forEach(function (param) {
+                        var argPropName = this._toParamPropertyName(param);
+
+                        if( this.hasOwnProperty(argPropName) ){
+                            this[argPropName] = params[param];
+                        }
+
+                    }.bind(this))
+                }
+                finally {
+                    delete this._syncing;
+                }
+            },
+
+            /**
+             * Builds the `args` section of the 'invoke' message by serializing each
+             * param as necessary.
+             */
+            _serializeParamsForSend: function(){
+                var serArgs = {};
+                Object.keys(this.args).filter(function(arg){
+                    //remove args that contain the default value.
+                    return this.spec[arg] && this.args[arg] !== this.spec[arg].value;
+                }.bind(this)).forEach(function(arg){
+                    var value = this.args[arg];
+                    serArgs[arg] = (typeof value == 'boolean') ? value : this.serialize(value);
+                }.bind(this));
+
+                return serArgs;
+            },
+
+            _isParameterAttribute: function(attr /*attribute or string*/){
+                var attrName =  typeof attr === 'string' ? attr : attr.name;
+                return ParamAttrPattern.test(attrName);
+            },
+
+            /**
+             * Returns false if paramValue is undefined, null and NaN.
+             *
+             * @method _isParameterUnset
+             * @param {*} paramValue Any value sent to test
+             * @return {boolean} true if considered unset
+             */
+            _isParameterUnset: function(paramValue){
+                /*
+                 * Testing undefined, null and NaN.
+                 * From https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/NaN#Testing_against_NaN
+                 * a valid test for NaN is to test inequality to itself.
+                 */
+                return paramValue === undefined || paramValue == null || (paramValue !== paramValue);
+            },
+
+            _toParamName: function(attr /*attribute or string*/){
+                var attrName =  typeof attr === 'string' ? attr : attr.name;
+
+                var matches = ParamAttrPattern.exec(attrName)
+                return matches && matches.length === 2 ? matches[1] : undefined;
+            },
+
+            _toParamPropertyName: function(paramName){
+                return 'trait' + paramName[0].toUpperCase() + paramName.substring(1);
+            },
+
+            _toParamPropertyObserverName: function(paramName){
+                var paramPropName = this._toParamPropertyName(paramName);
+                return '_on'+paramPropName[0].toUpperCase() + paramPropName.substring(1)+'Change'
+            },
+
+            _paramsFromAttributes: function(){
+                var attrs = this.attributes,
+                        params = {};
+
+                for (var i = 0; i < attrs.length; i++) {
+                    var attr = attrs[i];
+                    if (this._isParameterAttribute(attr)) {
+                        params[this._toParamName(attr)] = attr.nodeValue;
+                    }
+                }
+
+                return params;
+            },
+
+            _onParameterChange: function( argName, argValue ){
+                console.debug("urth-viz-ipywidget _onParameterChange", argName, argValue);
+
+                if( this.isConnected() ){
+                    this.model.widget_manager.get_model(this.modelId).then(function(m){
+                        m.set(argName, argValue);
+                        m.save_changes();
+                    }.bind(this));
+                }
+            },
+
+            /**
+             * This method handles changes to the spec of the widget. It will create a new property based on
+             * the name of the traits. These new properties will allow data binding and will be kept in sync with
+             * the contents of the `traits` property.
+             *
+             */
+            _onSpecChange: function(sig){
+                console.debug('urth-viz-ipywidget _onSignatureChange got new signature', sig);
+                this._clearErrorMessages();
+                this.resetDynamicProperties();
+
+                var paramNames = Object.keys(sig);
+                if( paramNames.length > 0 ){
+
+                    //create new properties based on signature
+                    var paramProperties = {}
+                    paramNames.forEach(function(param){
+                        var argPropName = this._toParamPropertyName(param);
+                        var argPropObserverName = this._toParamPropertyObserverName(param);
+
+                        //create an observer
+                        this[argPropObserverName] = this._createArgChangeHandler(param);
+
+                        paramProperties[argPropName] = {
+                            notify: true,
+                            reflectToAttribute: true,
+                            observer: argPropObserverName,
+                            value: this[argPropName] !== undefined ? this[argPropName] : sig[param]
+                        }
+
+                    }.bind(this));
+
+                    this.setDynamicProperties(paramProperties);
+
+                    //set the defaults values and sync if necessary
+                    var paramsToSync = {};
+
+                    paramNames.forEach(function(param){
+                        if(this._isParameterUnset(this.traits[param])){
+                            var propValue = paramProperties[this._toParamPropertyName(param)].value
+                            if( propValue !== undefined ) {
+                                this.set('traits.' + param, propValue);
+                            }
+                        }
+                        else{
+                            paramsToSync[param] = this.traits[param];
+                        }
+                    }.bind(this));
+
+                    this._syncParamAttributes(paramsToSync);
+                }
+            },
+
+            /**
+             * Update the `spec` held by this element with
+             * the spec of the widget currently in the kernel.
+             *
+             * @method refresh
+             */
+            refresh: function() {
+                console.debug("urth-viz-ipywidget sending sync message...");
+                this.send({ "event": "sync" });
+            },
+
+            _createArgChangeHandler: function(param){
+
+                return function(newVal){
+                    console.log('urth-viz-ipywidget handling change to', param);
+
+                    if(this._syncing)
+                        return;
+
+                    this._syncing = true;
+                    try {
+                        this.set("traits." + param, newVal); //keep the property updated
+                        this._onParameterChange(param, newVal);
+                    }
+                    finally {
+                        delete this._syncing;
+                    }
+                }
+            }
+    });
+})();
+
+</script>

--- a/elements/urth-viz-ipywidget/urth-viz-ipywidget.html
+++ b/elements/urth-viz-ipywidget/urth-viz-ipywidget.html
@@ -260,7 +260,7 @@ names for these properties have the form `trait-<name of trait>`.
              *
              */
             _onWidgetModelChange: function(){
-                console.debug('urth-viz-ipywidget _setupTraits got new signature', traits);
+                console.debug('urth-viz-ipywidget _onWidgetModelChange');
                 this._clearErrorMessages();
 
                 //hook listener to model changes
@@ -277,6 +277,7 @@ names for these properties have the form `trait-<name of trait>`.
             },
 
             _setupTraitProperties: function(widgetTraits){
+                console.debug('urth-viz-ipywidget _setupTraitProperties', widgetTraits);
                 this.resetDynamicProperties();
 
                 //get the traits to expose them as properties

--- a/elements/urth-viz-ipywidget/urth-viz-ipywidget.html
+++ b/elements/urth-viz-ipywidget/urth-viz-ipywidget.html
@@ -6,10 +6,12 @@
 <link rel="import" href="../urth-core-behaviors/jupyter-widget-behavior.html">
 <link rel='import' href='../urth-core-behaviors/dynamic-properties-behavior.html'>
 <link rel="import" href="../urth-core-behaviors/execution-complete-behavior.html">
+<link rel="import" href="../urth-core-behaviors/jupyter-kernel-observer.html">
 
 <!--
-Allows displaying and binding with ipywidgets. This element only works against a Python
-kernel that has ipywidgets 4.x installed.
+This elements finds an ipywidget instance in the kernel that is referred to by the name specified in the `ref`
+property. It displays the ipywidget in its Local DOM and exposes the ipywidget's traits as properties available
+for template binding. This element only works against a Python kernel that has ipywidgets installed.
 
 To use this element, first create an instance of an ipywidget and assign it to a
 variable name.
@@ -45,7 +47,7 @@ names for these properties have the form `trait-<name of trait>`.
             properties: {
 
                 /**
-                 * Name of the widget to proxy. Must be a widget that is
+                 * Name of the variable that references the widget to proxy. Must be a widget that is
                  * defined in the kernel.
                  */
                 ref: {
@@ -54,21 +56,24 @@ names for these properties have the form `trait-<name of trait>`.
                 },
 
                 /**
-                 * The id of the ipywidget model.
+                 * The id of the ipywidget model. This is set through communication with the kernel.
                  */
                 modelId: {
                     type: String,
                     readOnly: true
                 },
 
+                /**
+                 * The WidgetModel instance for the ipywidget. This is set once the `modelId` is known.
+                 */
                 widgetModel: {
                     type: Object,
                     readOnly: true
                 },
 
                 /**
-                 * Object reflecting the current values of the traits of the
-                 * widget. This property can be used for binding.
+                 * Object reflecting the current values of all the traits define in the
+                 * ipywidget. This property can be used for binding.
                  */
                 traits: {
                     type: Object,
@@ -79,7 +84,8 @@ names for these properties have the form `trait-<name of trait>`.
             behaviors: [
                 Urth.JupyterWidgetBehavior,
                 Urth.ExecutionCompleteBehavior,
-                Urth.DynamicPropertiesBehavior
+                Urth.DynamicPropertiesBehavior,
+                Urth.JupyterKernelObserver
             ],
 
             observers: [
@@ -88,21 +94,21 @@ names for these properties have the form `trait-<name of trait>`.
                 '_onWidgetModelChange(widgetModel)'
             ],
 
-            created: function(){
-                console.debug('urth-viz-ipywidget created', arguments);
+            onKernelReady: function(kernel){
+                console.debug('urth-viz-ipywidget onKernelReady', arguments);
 
-                //only operate if the kernel is python
-                Urth.kernel.get_info(function(info){
+                //Need to know the kernel language to continue creation
+                kernel.get_info(this._onKernelInfo.bind(this))
+            },
 
-                    if(info.name.indexOf('python') == 0 ) {
-                        this.createModel('urth.widgets.widget_ipw_proxy.IpywProxy');
-                    }
-                    else{
-                        //not supported on any other kernels
-                        this.displayErrorMessage('Unsupported kernel. This element only supports Python.');
-                    }
-                }.bind(this))
-
+            _onKernelInfo: function(info){
+                if(info.name.indexOf('python') == 0 ) {
+                    this.createModel('urth.widgets.widget_ipw_proxy.IpywProxy');
+                }
+                else{
+                    //not supported on any other kernels
+                    this.displayErrorMessage('Unsupported kernel. This element only supports Python.');
+                }
             },
 
             ready: function() {
@@ -131,12 +137,7 @@ names for these properties have the form `trait-<name of trait>`.
 
             onModelIdChange: function(modelid){
                 console.debug('urth-viz-ipywidget onModelIdChange', modelid);
-                console.debug('urth-viz-ipywidget rendering view');
-
                 this._setModelId(modelid);
-
-                //set the widgetModel
-
             },
 
             /*
@@ -156,7 +157,7 @@ names for these properties have the form `trait-<name of trait>`.
                 console.debug('urth-viz-ipywidget _onTraitPropertyChanged', rec);
                 if( rec.path === 'traits' ){
                     //entire parameter map changed
-                    this._syncTraitAttributes(rec.value);
+                    this._syncTraitProperty(rec.value);
                     this._onTraitChange(rec.path, rec.value);
                 }
                 else if (TraitPropPathPattern.test(rec.path)){
@@ -170,7 +171,7 @@ names for these properties have the form `trait-<name of trait>`.
                         var traits = {};
                         var newVal = rec.base[trait];
                         traits[trait] = newVal;
-                        this._syncTraitAttributes(traits);
+                        this._syncTraitProperty(traits);
                         this._onTraitChange(trait, newVal);
 
                     }
@@ -181,7 +182,7 @@ names for these properties have the form `trait-<name of trait>`.
                 this.refresh();
             },
 
-            _syncTraitAttributes: function( traits ){
+            _syncTraitProperty: function( traits ){
                 traits = !traits ? {} : traits;
                 this._syncing = true;
                 try {
@@ -261,7 +262,6 @@ names for these properties have the form `trait-<name of trait>`.
             _onWidgetModelChange: function(){
                 console.debug('urth-viz-ipywidget _setupTraits got new signature', traits);
                 this._clearErrorMessages();
-                this.resetDynamicProperties();
 
                 //hook listener to model changes
                 this.widgetModel.on('change', function(options){
@@ -271,13 +271,20 @@ names for these properties have the form `trait-<name of trait>`.
                     }.bind(this));
                 }.bind(this));
 
+                this._setupTraitProperties(this.widgetModel.attributes)
+
+                this._createWidgetView();
+            },
+
+            _setupTraitProperties: function(widgetTraits){
+                this.resetDynamicProperties();
 
                 //get the traits to expose them as properties
                 var traits = {};
-                Object.keys(this.widgetModel.attributes).filter(function(attribute){
+                Object.keys(widgetTraits).filter(function(attribute){
                     return attribute.indexOf("_") != 0;
                 }).forEach(function(attribute){
-                    traits[attribute] = this.widgetModel.attributes[attribute];
+                    traits[attribute] = widgetTraits[attribute];
                 }.bind(this));
 
                 var paramNames = Object.keys(traits);
@@ -318,15 +325,12 @@ names for these properties have the form `trait-<name of trait>`.
                         }
                     }.bind(this));
 
-                    this._syncTraitAttributes(paramsToSync);
+                    this._syncTraitProperty(paramsToSync);
 
                     //update the widgetmodel with what was set on init
                     Object.keys(paramsToSync).forEach(function (trait) {
                         this._onTraitChange(trait, paramsToSync[trait]);
                     }.bind(this))
-
-                    //create the view
-                    this._createWidgetView();
 
                 }
             },
@@ -340,8 +344,8 @@ names for these properties have the form `trait-<name of trait>`.
             },
 
             /**
-             * Update the `spec` held by this element with
-             * the spec of the widget currently in the kernel.
+             * Sends a sync message to the kernel side. This is intended to make sure this element is bound to the
+             * latest object referenced by `ref`.
              *
              * @method refresh
              */

--- a/etc/docs/urth-elements.html
+++ b/etc/docs/urth-elements.html
@@ -26,3 +26,4 @@
 <link rel='import' href='../../bower_components/urth-viz-pie/urth-viz-pie.html'>
 <link rel='import' href='../../bower_components/urth-viz-scatter/urth-viz-scatter.html'>
 <link rel='import' href='../../bower_components/urth-viz-table/urth-viz-table.html'>
+<link rel='import' href='../../bower_components/urth-viz-ipywidget/urth-viz-ipywidget.html'>

--- a/etc/notebooks/examples/urth-viz-ipywidget.ipynb
+++ b/etc/notebooks/examples/urth-viz-ipywidget.ipynb
@@ -1,0 +1,357 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "\n",
+    "\n",
+    "### urth-viz-ipywidget Examples"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "#### Import dependencies"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "%%html\n",
+    "<link rel='import' href='urth_components/urth-viz-ipywidget/urth-viz-ipywidget.html' is='urth-core-import'>\n",
+    "<link rel='import' href='urth_components/paper-slider/paper-slider.html'\n",
+    "        is='urth-core-import' package='PolymerElements/paper-slider'>"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "from ipywidgets import widgets # Widget definitions\n",
+    "from IPython.display import display # Used to display widgets in the notebook"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Example 1a: Display ipywidget using markup"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": [
+    "slider = widgets.FloatSlider(value=0,min=0,max=200,step=1)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "%%html\n",
+    "<urth-viz-ipywidget ref=\"slider\"></urth-viz-ipywidget>"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "slider.value = 150"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "collapsed": true
+   },
+   "source": [
+    "### Example 1b: Setting traits using element properties"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "%%html\n",
+    "<template is=\"dom-bind\">\n",
+    "    <urth-viz-ipywidget ref=\"slider\" trait-value=\"10\" trait-min=\"0\" trait-max=\"20\"></urth-viz-ipywidget>\n",
+    "</template>"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "collapsed": true
+   },
+   "source": [
+    "### Example 2a: Display ipywidget within a template"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "%%html\n",
+    "<template is=\"dom-bind\">\n",
+    "    <urth-viz-ipywidget ref=\"slider\" trait-value=\"{{val}}\" trait-min=\"{{min}}\" trait-max=\"{{max}}\"></urth-viz-ipywidget>\n",
+    "    <div>val: <input value=\"{{val::change}}\"></input></div>\n",
+    "    <div>min: <input value=\"{{min::change}}\"></input></div>\n",
+    "    <div>max: <input value=\"{{max::change}}\"></input></div>\n",
+    "</template>"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Example 2b: Linking ipywidgets using template bindings"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "a = widgets.FloatText()\n",
+    "b = widgets.FloatSlider()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "%%html\n",
+    "<template is=\"dom-bind\">\n",
+    "    <urth-viz-ipywidget ref=\"a\" trait-value=\"{{val}}\"></urth-viz-ipywidget>\n",
+    "    <urth-viz-ipywidget ref=\"b\" trait-value=\"{{val}}\"></urth-viz-ipywidget>\n",
+    "</template>"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Example 2c: Linking ipywidgets with other Polymer elements"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "%%html\n",
+    "<template is=\"dom-bind\">\n",
+    "    <urth-viz-ipywidget ref=\"a\" trait-value=\"{{val}}\"></urth-viz-ipywidget>\n",
+    "    <paper-slider min=\"10\" max=\"100\" step=\"1\" value=\"{{val}}\"></paper-slider>\n",
+    "</template>"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Example 2d: Linking ipywidgets with other urth elements"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": [
+    "def aFunction( val = 5 ):\n",
+    "    return val * 100"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "%%html\n",
+    "<template is=\"dom-bind\">\n",
+    "    <urth-core-function ref=\"aFunction\" arg-val=\"{{val}}\" result=\"{{res}}\" auto></urth-core-function>\n",
+    "    <urth-viz-ipywidget ref=\"slider\" trait-value=\"{{val}}\"></urth-viz-ipywidget>\n",
+    "    <span>{{res}}</span>\n",
+    "</template>"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Example 3: Display 3rd party ipywidgets (bqplot)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "<div class=\"alert alert-info\" role=\"alert\" style=\"margin-top: 10px\">\n",
+    "        <p><strong>Note:</strong> The following cells will install `bqplot`. Only needed once.</p>\n",
+    "</div>"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "!pip install bqplot"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "!python -m bqplot.install --symlink --user --force"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "<div class=\"alert alert-info\" role=\"alert\" style=\"margin-top: 10px\">\n",
+    "<p><strong>Note:</strong> If this is the first time you install bqplot, you need to save this notebook and refresh.</p>\n",
+    "</div>"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "import bqplot as bq\n",
+    "import numpy as np\n",
+    "\n",
+    "size = 20\n",
+    "np.random.seed(0)\n",
+    "\n",
+    "x_data = np.arange(size)\n",
+    "\n",
+    "x_ord = bq.OrdinalScale()\n",
+    "y_sc = bq.LinearScale()\n",
+    "\n",
+    "bar = bq.Bars(x=x_data, y=np.random.randn(2, size), scales={'x': x_ord, 'y': y_sc},\n",
+    "              type='stacked')\n",
+    "line = bq.Lines(x=x_data, y=np.random.randn(size), scales={'x': x_ord, 'y': y_sc},\n",
+    "                stroke_width=3, colors=['red'], display_legend=True, labels=['Line chart'])\n",
+    "\n",
+    "ax_x = bq.Axis(scale=x_ord)\n",
+    "ax_y = bq.Axis(scale=y_sc, orientation='vertical', tick_format='0.2f', grid_lines='solid')\n",
+    "\n",
+    "fig = bq.Figure(marks=[bar, line], axes=[ax_x, ax_y])\n",
+    "toolbar = bq.Toolbar(figure=fig)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false,
+    "scrolled": false
+   },
+   "outputs": [],
+   "source": [
+    "%%html\n",
+    "<template is=\"dom-bind\">\n",
+    "    <urth-viz-ipywidget ref=\"toolbar\"></urth-viz-ipywidget>\n",
+    "    <urth-viz-ipywidget ref=\"fig\"></urth-viz-ipywidget>\n",
+    "</template>"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "cell_tags": [
+   [
+    "<None>",
+    null
+   ]
+  ],
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.5.1"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 0
+}

--- a/etc/notebooks/examples/urth-viz-ipywidget.ipynb
+++ b/etc/notebooks/examples/urth-viz-ipywidget.ipynb
@@ -18,11 +18,26 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 24,
    "metadata": {
     "collapsed": false
    },
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<link rel='import' href='urth_components/urth-viz-ipywidget/urth-viz-ipywidget.html' is='urth-core-import'>\n",
+       "<link rel='import' href='urth_components/paper-slider/paper-slider.html'\n",
+       "        is='urth-core-import' package='PolymerElements/paper-slider'>"
+      ],
+      "text/plain": [
+       "<IPython.core.display.HTML object>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
    "source": [
     "%%html\n",
     "<link rel='import' href='urth_components/urth-viz-ipywidget/urth-viz-ipywidget.html' is='urth-core-import'>\n",
@@ -32,7 +47,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 25,
    "metadata": {
     "collapsed": false
    },
@@ -51,7 +66,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 26,
    "metadata": {
     "collapsed": true
    },
@@ -62,11 +77,24 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 30,
    "metadata": {
     "collapsed": false
    },
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<urth-viz-ipywidget ref=\"slider\"></urth-viz-ipywidget>"
+      ],
+      "text/plain": [
+       "<IPython.core.display.HTML object>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
    "source": [
     "%%html\n",
     "<urth-viz-ipywidget ref=\"slider\"></urth-viz-ipywidget>"
@@ -74,7 +102,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 31,
    "metadata": {
     "collapsed": false
    },
@@ -94,11 +122,26 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 32,
    "metadata": {
     "collapsed": false
    },
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<template is=\"dom-bind\">\n",
+       "    <urth-viz-ipywidget ref=\"slider\" trait-value=\"10\" trait-min=\"0\" trait-max=\"20\"></urth-viz-ipywidget>\n",
+       "</template>"
+      ],
+      "text/plain": [
+       "<IPython.core.display.HTML object>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
    "source": [
     "%%html\n",
     "<template is=\"dom-bind\">\n",
@@ -117,11 +160,29 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 33,
    "metadata": {
     "collapsed": false
    },
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<template is=\"dom-bind\">\n",
+       "    <urth-viz-ipywidget ref=\"slider\" trait-value=\"{{val}}\" trait-min=\"{{min}}\" trait-max=\"{{max}}\"></urth-viz-ipywidget>\n",
+       "    <div>val: <input value=\"{{val::change}}\"></input></div>\n",
+       "    <div>min: <input value=\"{{min::change}}\"></input></div>\n",
+       "    <div>max: <input value=\"{{max::change}}\"></input></div>\n",
+       "</template>"
+      ],
+      "text/plain": [
+       "<IPython.core.display.HTML object>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
    "source": [
     "%%html\n",
     "<template is=\"dom-bind\">\n",
@@ -141,7 +202,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 34,
    "metadata": {
     "collapsed": false
    },
@@ -153,11 +214,27 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 35,
    "metadata": {
     "collapsed": false
    },
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<template is=\"dom-bind\">\n",
+       "    <urth-viz-ipywidget ref=\"a\" trait-value=\"{{val}}\"></urth-viz-ipywidget>\n",
+       "    <urth-viz-ipywidget ref=\"b\" trait-value=\"{{val}}\"></urth-viz-ipywidget>\n",
+       "</template>"
+      ],
+      "text/plain": [
+       "<IPython.core.display.HTML object>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
    "source": [
     "%%html\n",
     "<template is=\"dom-bind\">\n",

--- a/etc/notebooks/tests/Walkthrough.ipynb
+++ b/etc/notebooks/tests/Walkthrough.ipynb
@@ -343,6 +343,51 @@
    "source": [
     "Click [here](../examples/urth-core-import.ipynb) to learn more about `<urth-core-import>`"
    ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Embedding ipywidgets"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "%%html\n",
+    "<link rel='import' href='urth_components/urth-viz-ipywidget/urth-viz-ipywidget.html' is='urth-core-import'>"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": [
+    "from ipywidgets import widgets # Widget definitions\n",
+    "from IPython.display import display # Used to display widgets in the notebook\n",
+    "\n",
+    "slider = widgets.FloatSlider(value=0,min=0,max=200,step=1)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "%%html\n",
+    "<urth-viz-ipywidget id=\"ipywid\" ref=\"slider\"></urth-viz-ipywidget>"
+   ]
   }
  ],
  "metadata": {
@@ -361,7 +406,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.4.3"
+   "version": "3.5.1"
   }
  },
  "nbformat": 4,

--- a/kernel-python/urth/widgets/widget_ipw_proxy.py
+++ b/kernel-python/urth/widgets/widget_ipw_proxy.py
@@ -1,0 +1,52 @@
+# Copyright (c) Jupyter Development Team.
+# Distributed under the terms of the Modified BSD License.
+
+from traitlets import Unicode # Used to declare attributes of our widget
+from IPython.core.getipython import get_ipython
+
+from .urth_widget import UrthWidget
+from .urth_exception import UrthException
+
+
+class IpywProxy(UrthWidget):
+    """
+    A Widget to prowy IPywidgets
+    """
+    widget_name = Unicode('', sync=True)
+
+    def __init__(self, **kwargs):
+        self.log.info("Created a new IpywProxy widget.")
+
+        self.on_msg(self._handle_custom_event_msg)
+        self.shell = get_ipython()
+
+        super(IpywProxy, self).__init__(**kwargs)
+
+    def _widget_name_changed(self, old, new):
+        try:
+            self.log.info("Binding to widget name {}...".format(new))
+            self._sync_state()
+            self.ok()
+        except Exception as e:
+            self.error(str(e))
+
+    def _handle_custom_event_msg(self, wid, content, buffers):
+        event = content.get('event', '')
+        if event == 'sync':
+            self._sync_state()
+
+    def _the_widget(self):
+        if self.widget_name in self.shell.user_ns:
+            return self.shell.user_ns[self.widget_name]
+        else:
+            raise UrthException("Could not find a widget with name {}".format(
+                self.widget_name))
+
+    def _sync_state(self):
+        try:
+            the_widget = self._the_widget()
+            # display the widget
+            self._send_update("id", the_widget.model_id)
+
+        except Exception as e:
+            self.error("Error while getting the ipywidget model id: {}".format(str(e)))

--- a/system-test/urth-system-test-specs.js
+++ b/system-test/urth-system-test-specs.js
@@ -68,4 +68,13 @@ describe('Widgets System Test', function() {
             .waitForElementByClassName('test5', wd.asserters.textInclude('Jane Doe'), 10000)
             .nodeify(done);
     });
+
+    it('should render ipywidget when using urth-viz-ipywidget', function(done) {
+
+        var ipySlider = '#ipywid .widget-slider';
+
+        boilerplate.browser
+            .waitForElementsByCssSelector(ipySlider, wd.asserters.isDisplayed, 10000)
+            .nodeify(done);
+    });
 });


### PR DESCRIPTION
Implements the `urth-viz-ipywidget` to allow creating views of ipywidgets within a declarative template. It exposes all `traits` as element properties that can be used for binding.

fixes #302

This PR needs:
- [x] render ipywidget within the element
- [x] expose the traits as properties to use in binding
- [x] add documentation and add to docs
- [x] protect agains using element in any kernel other than python
- [x] validate that referred object is a valid ipywidget (basically, does it have a model_id)  
- [x] add unit test
- [x] add to the system test
