### PR TITLE
Enables support for ipywidgets 5.0 and retains 4.x support

### DIFF
--- a/elements/urth-core-behaviors/jupyter-widget-behavior.html
+++ b/elements/urth-core-behaviors/jupyter-widget-behavior.html
@@ -47,7 +47,7 @@ This behavior is used to encapsulate some of the services needed for ipywidgets.
                 console.debug('Urth.JupyterWidgetBehavior createModel', this.kernelClass);
                 Urth.kernel.widget_manager.new_widget(
                     {
-                        model_module: 'nbextensions/urth_widgets/js/widgets/DeclWidgetModel',
+                        model_module: 'jupyter-decl-widgets/DeclWidgetModel',
                         model_name: 'DeclWidgetModel',
                         widget_class: this.kernelClass
                     }

--- a/nb-extension/js/main.js
+++ b/nb-extension/js/main.js
@@ -11,15 +11,24 @@ define([
 
     'use strict';
 
-    //create a mapping for declarativewidgets
+    //create a mapping for declarativewidgets and its dependencies
     requirejs.config({
         map: {
             '*': {
                 'jupyter-decl-widgets': 'nbextensions/urth_widgets/js/widgets'
+            },
+            'nbextensions/urth_widgets/js/widgets': {
+                'jupyter-js-widgets': 'ipywidgets4-or-jupyter-js-widgets'
             }
+        },
+        paths: {
+            'ipywidgets4-or-jupyter-js-widgets': [
+                'does/not/exist',  //HACK: fallbacks was acting strange with 2 items
+                Jupyter.notebook.base_url+'nbextensions/widgets/widgets/js/widget',
+                Jupyter.notebook.base_url+'nbextensions/jupyter-js-widgets/extension',
+            ]
         }
     });
-
 
     // Some versions of IE do not have window.console defined. Some versions
     // do not define the debug and other methods. This is a minimal workaround
@@ -51,6 +60,6 @@ define([
     load_css(getModuleBasedComponentRoot() + '/../css/main.css');
 
     return {
-        load_ipython_extension: function() { console.debug('Custom JS loaded'); }
+        load_ipython_extension: function() { console.debug('loaded declarativewidgets'); }
     };
 });

--- a/nb-extension/js/main.js
+++ b/nb-extension/js/main.js
@@ -11,6 +11,16 @@ define([
 
     'use strict';
 
+    //create a mapping for declarativewidgets
+    requirejs.config({
+        map: {
+            '*': {
+                'jupyter-decl-widgets': 'nbextensions/urth_widgets/js/widgets'
+            }
+        }
+    });
+
+
     // Some versions of IE do not have window.console defined. Some versions
     // do not define the debug and other methods. This is a minimal workaround
     // based on what declarative widgets code is using.

--- a/nb-extension/js/widgets/DeclWidgetModel.js
+++ b/nb-extension/js/widgets/DeclWidgetModel.js
@@ -1,15 +1,15 @@
 // Copyright (c) Jupyter Development Team.
 // Distributed under the terms of the Modified BSD License.
 
-define(["nbextensions/widgets/widgets/js/widget"], function(Widget) {
+define(["jupyter-js-widgets"], function(widgets) {
     "use strict";
 
     /**
      * Collection of patches on top of ipywidgets.WidgetModel
      */
-    var DeclWidgetModel = Widget.WidgetModel.extend({
+    var DeclWidgetModel = widgets.WidgetModel.extend({
         constructor: function() {
-            Widget.WidgetModel.apply(this, arguments);
+            widgets.WidgetModel.apply(this, arguments);
             // WidgetModel expects widgets' state to be set from kernel and won't
             // set `_first_state` to false until that happens. But DeclWidgets
             // are different: we do initial setup on client and then notify kernel.


### PR DESCRIPTION
This PR adds support on our main.js to load the JS for the corresponding ipywidgets version. The imminent release of ipywidgets 5.0 is based on the split of the project. The JS is no known as jupyter-js-widgets and it is located under a different module path from the 4.x javascript.

The goal is for declarativewidgets to work properly on either version.

To test this, I did the following

```
make dev CMD=bash

# uninstall old ipywidgets
pip uninstall ipywidgets

# upgrade notebook to 4.2
pip install --upgrade notebook

# install ipywidgest 5.0.0b4
pip install --pre ipywidgets
pip install --upgrade widgetsnbextension
jupyter nbextension install --py --user widgetsnbextension
jupyter nbextension enable widgetsnbextension --user --py
```

resolves #292
