### PR TITLE
Add support for new Jupyter 4.2 extension installation

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,2 +1,2 @@
-recursive-include urth/widgets/ext/notebook *.html *.js *.css *.jar *.json *.tgz
+recursive-include declarativewidgets/static *.html *.js *.css *.jar *.json *.tgz
 include VERSION

--- a/Makefile
+++ b/Makefile
@@ -297,7 +297,7 @@ server: VOL_MAP?=-v `pwd`/etc/notebooks:/home/jovyan/work
 server: _run-$(PYTHON)
 
 server_4.2: CMD?=jupyter notebook --no-browser --port 8888 --ip="*"
-server_4.2: INSTALL_DECLWID_CMD?=pip install --pre --upgrade toree && jupyter toree install --user; pip install --no-binary ::all: $$(ls -1 /src/dist/*.tar.gz | tail -n 1) && jupyter nbextension install --py declarativewidgets --user && jupyter nbextension enable --py declarativewidgets --user && jupyter serverextension enable --py declarativewidgets --user && jupyter declarativewidgets installr --library=/opt/conda/lib/R/library;
+server_4.2: INSTALL_DECLWID_CMD?=pip install --pre --upgrade toree && jupyter toree install --user; pip install --no-binary ::all: $$(ls -1 /src/dist/*.tar.gz | tail -n 1) && jupyter nbextension install --py declarativewidgets --sys-prefix && jupyter nbextension enable --py declarativewidgets --sys-prefix && jupyter serverextension enable --py declarativewidgets --sys-prefix && jupyter declarativewidgets installr --library=/opt/conda/lib/R/library;
 server_4.2: SERVER_NAME?=urth_widgets_server
 server_4.2: OPTIONS?=-it --rm
 server_4.2: PORT_MAP?=-p 9500:8888

--- a/Makefile
+++ b/Makefile
@@ -139,6 +139,11 @@ dist/urth: ${shell find kernel-python/urth} dist/urth/widgets/ext dist/urth/widg
 	@mkdir -p dist/urth
 	@cp -R kernel-python/urth/* dist/urth/.
 
+dist/declarativewidgets: ${shell find kernel-python/declarativewidgets} ${shell find nb-extension/python/declarativewidgets}
+	@echo 'Building declarativewidgets python module'
+	@mkdir -p dist/declarativewidgets
+	@cp -R nb-extension/python/declarativewidgets/* dist/declarativewidgets/.
+
 dist/urth/widgets/ext/notebook/urth-widgets.jar: ${shell find kernel-scala/src/main/scala/}
 ifeq ($(NOSCALA), true)
 	@echo 'Skipping scala code'
@@ -201,7 +206,7 @@ dist/VERSION:
 	@mkdir -p dist
 	@echo "$(COMMIT)" > dist/VERSION
 
-dist: dist/urth dist/urth/widgets/ext/notebook/urth-widgets.jar dist/urth/widgets/ext/notebook/urth-widgets.tgz dist/scripts dist/VERSION dist/urth/widgets/ext/notebook/docs
+dist: dist/urth dist/declarativewidgets dist/urth/widgets/ext/notebook/urth-widgets.jar dist/urth/widgets/ext/notebook/urth-widgets.tgz dist/scripts dist/VERSION dist/urth/widgets/ext/notebook/docs
 
 sdist: dist
 	@cp -R MANIFEST.in dist/.

--- a/Makefile
+++ b/Makefile
@@ -297,7 +297,7 @@ server: VOL_MAP?=-v `pwd`/etc/notebooks:/home/jovyan/work
 server: _run-$(PYTHON)
 
 server_4.2: CMD?=jupyter notebook --no-browser --port 8888 --ip="*"
-server_4.2: INSTALL_DECLWID_CMD?=pip install --pre --upgrade toree && jupyter toree install --user; pip install --no-binary ::all: $$(ls -1 /src/dist/*.tar.gz | tail -n 1) && jupyter nbextension install --py declarativewidgets --sys-prefix && jupyter nbextension enable --py declarativewidgets --sys-prefix && jupyter serverextension enable --py declarativewidgets --sys-prefix && jupyter declarativewidgets installr --library=/opt/conda/lib/R/library;
+server_4.2: INSTALL_DECLWID_CMD?=pip install --pre --upgrade toree && jupyter toree install --user; pip install --no-binary ::all: $$(ls -1 /src/dist/*.tar.gz | tail -n 1) && jupyter declarativewidgets quick-setup --sys-prefix && jupyter declarativewidgets installr --library=/opt/conda/lib/R/library;
 server_4.2: SERVER_NAME?=urth_widgets_server
 server_4.2: OPTIONS?=-it --rm
 server_4.2: PORT_MAP?=-p 9500:8888

--- a/Makefile
+++ b/Makefile
@@ -114,80 +114,81 @@ clean-watch-docs:
 	-@kill -9 `pgrep -P $$(cat .watch-docs)`
 	-@rm .watch-docs
 
-dist/urth/widgets/ext/notebook/css: ${shell find nb-extension/css}
-	@echo 'Moving nb-extension/css'
-	@mkdir -p dist/urth/widgets/ext/notebook/css
-	@cp -R nb-extension/css/* dist/urth/widgets/ext/notebook/css/.
-
-dist/urth/widgets/ext/notebook/js: ${shell find nb-extension/js}
-	@echo 'Moving src/nb-extension'
-	@mkdir -p dist/urth/widgets/ext/notebook/js
-	@cp -R nb-extension/js/* dist/urth/widgets/ext/notebook/js/.
-
-dist/urth/widgets/ext/notebook/elements: ${shell find elements}
-	@echo 'Moving elements'
-	@mkdir -p dist/urth/widgets/ext/notebook/elements
-	@cp -R elements/* dist/urth/widgets/ext/notebook/elements/.
-	@touch dist/urth/widgets/ext/notebook/elements
-
-dist/urth/widgets/ext/notebook/urth_components: bower_components ${shell find elements} | $(URTH_COMP_LINKS)
-	@echo 'Moving bower_components'
-	@mkdir -p dist/urth/widgets/ext/notebook/urth_components
-	@cp -RL bower_components/* dist/urth/widgets/ext/notebook/urth_components/.
-
-dist/urth/widgets/ext/notebook/docs: dist/docs
-	@echo 'Copying dist/docs/site'
-	@mkdir -p dist/urth/widgets/ext/notebook/docs
-	@cp -R dist/docs/site/* dist/urth/widgets/ext/notebook/docs/.
-
-dist/urth/widgets/ext/notebook: dist/urth/widgets/ext/notebook/bower.json dist/urth/widgets/ext/notebook/urth_components dist/urth/widgets/ext/notebook/js dist/urth/widgets/ext/notebook/elements dist/urth/widgets/ext/notebook/css
-
 dist/urth/widgets/ext: ${shell find nb-extension/python/urth/widgets/ext}
 	@echo 'Moving frontend extension code'
 	@mkdir -p dist/urth/widgets/ext
 	@cp -R nb-extension/python/urth/widgets/ext/* dist/urth/widgets/ext/.
 
-dist/urth: ${shell find kernel-python/urth} dist/urth/widgets/ext dist/urth/widgets/ext/notebook
+dist/urth: ${shell find kernel-python/urth} dist/urth/widgets/ext
 	@echo 'Moving python code'
 	@mkdir -p dist/urth
 	@cp -R kernel-python/urth/* dist/urth/.
 
-dist/declarativewidgets: ${shell find kernel-python/declarativewidgets} ${shell find nb-extension/python/declarativewidgets}
-	@echo 'Building declarativewidgets python module'
+dist/declarativewidgets: dist/declarativewidgets/static ${shell find nb-extension/python/declarativewidgets}
 	@mkdir -p dist/declarativewidgets
+	@echo 'Building declarativewidgets python module'
 	@cp -R nb-extension/python/declarativewidgets/* dist/declarativewidgets/.
 
-dist/urth/widgets/ext/notebook/urth-widgets.jar: ${shell find kernel-scala/src/main/scala/}
+dist/declarativewidgets/static: bower.json dist/declarativewidgets/static/css dist/declarativewidgets/static/docs dist/declarativewidgets/static/elements dist/declarativewidgets/static/js dist/declarativewidgets/static/urth_components dist/declarativewidgets/static/urth-widgets.jar dist/declarativewidgets/static/urth-widgets.tgz
+	@cp bower.json dist/declarativewidgets/static/bower.json
+	@touch dist/declarativewidgets/static
+
+dist/declarativewidgets/static/css: ${shell find nb-extension/css}
+	@echo 'Building declarativewidgets/static/css'
+	@mkdir -p dist/declarativewidgets/static/css
+	@cp -R nb-extension/css/* dist/declarativewidgets/static/css/.
+
+dist/declarativewidgets/static/docs: dist/docs
+	@echo 'Building declarativewidgets/static/docs'
+	@mkdir -p dist/declarativewidgets/static/docs
+	@cp -R dist/docs/site/* dist/declarativewidgets/static/docs/.
+
+dist/declarativewidgets/static/elements: ${shell find elements}
+	@echo 'Building declarativewidgets/static/elements'
+	@mkdir -p dist/declarativewidgets/static/elements
+	@cp -R elements/* dist/declarativewidgets/static/elements/.
+	@touch dist/declarativewidgets/static/elements
+
+dist/declarativewidgets/static/js: ${shell find nb-extension/js}
+	@echo 'Building declarativewidgets/static/js'
+	@mkdir -p dist/declarativewidgets/static/js
+	@cp -R nb-extension/js/* dist/declarativewidgets/static/js/.
+
+dist/declarativewidgets/static/urth_components: bower_components ${shell find elements} | $(URTH_COMP_LINKS)
+	@echo 'Building declarativewidgets/static/urth_components'
+	@mkdir -p dist/declarativewidgets/static/urth_components
+	@cp -RL bower_components/* dist/declarativewidgets/static/urth_components/.
+	@touch dist/declarativewidgets/static/urth_components
+
+dist/declarativewidgets/static/urth-widgets.jar: ${shell find kernel-scala/src/main/scala/}
 ifeq ($(NOSCALA), true)
 	@echo 'Skipping scala code'
 else
 	@echo 'Building scala code'
-	@mkdir -p dist/urth/widgets/ext/notebook
+	@echo 'Building declarativewidgets/static/urth-widgets.jar'
+	@mkdir -p dist/declarativewidgets/static
 	@docker run -it --rm \
 		-v `pwd`:/src \
 		$(SCALA_BUILD_REPO) bash -c 'cp -r /src/kernel-scala /tmp/src && \
 			cd /tmp/src && \
 			mkdir -p /tmp/src/lib && cp /opt/toree/toree/lib/*.jar /tmp/src/lib/. && \
 			sbt package && \
-			cp target/scala-2.10/urth-widgets*.jar /src/dist/urth/widgets/ext/notebook/urth-widgets.jar'
+			cp target/scala-2.10/urth-widgets*.jar /src/dist/declarativewidgets/static/urth-widgets.jar'
 endif
 
-dist/urth/widgets/ext/notebook/bower.json: bower.json
-	@mkdir -p dist/urth/widgets/ext/notebook
-	@cp bower.json dist/urth/widgets/ext/notebook/bower.json
-
-dist/urth/widgets/ext/notebook/urth-widgets.tgz: ${shell find kernel-r/declarativewidgets}
+dist/declarativewidgets/static/urth-widgets.tgz: ${shell find kernel-r/declarativewidgets}
 ifeq ($(NOR), true)
 	@echo 'Skipping R code'
 else
 	@echo 'Building R code'
-	@mkdir -p dist/urth/widgets/ext/notebook
+	@echo 'Building declarativewidgets/static/urth-widgets.tgz'
+	@mkdir -p dist/declarativewidgets/static
 	@docker run -it --rm \
 		-v `pwd`:/src \
 		$(REPO) bash -c 'cp -r /src/kernel-r/declarativewidgets /tmp/src && \
 			cd /tmp/src && \
 			R CMD INSTALL --build . && \
-			cp declarativewidgets_0.1_R_x86_64-pc-linux-gnu.tar.gz /src/dist/urth/widgets/ext/notebook/urth-widgets.tgz'
+			cp declarativewidgets_0.1_R_x86_64-pc-linux-gnu.tar.gz /src/dist/declarativewidgets/static/urth-widgets.tgz'
 endif
 
 dist/docs: dist/docs/bower_components dist/docs/site dist/docs/site/generated_docs.json
@@ -219,7 +220,7 @@ dist/VERSION:
 	@mkdir -p dist
 	@echo "$(COMMIT)" > dist/VERSION
 
-dist: dist/urth dist/declarativewidgets dist/urth/widgets/ext/notebook/urth-widgets.jar dist/urth/widgets/ext/notebook/urth-widgets.tgz dist/scripts dist/VERSION dist/urth/widgets/ext/notebook/docs
+dist: dist/urth dist/declarativewidgets dist/scripts dist/VERSION
 
 sdist: dist
 	@cp -R MANIFEST.in dist/.

--- a/Makefile
+++ b/Makefile
@@ -297,7 +297,7 @@ server: VOL_MAP?=-v `pwd`/etc/notebooks:/home/jovyan/work
 server: _run-$(PYTHON)
 
 server_4.2: CMD?=jupyter notebook --no-browser --port 8888 --ip="*"
-server_4.2: INSTALL_DECLWID_CMD?=pip install --no-binary ::all: $$(ls -1 /src/dist/*.tar.gz | tail -n 1) && jupyter nbextension install --py declarativewidgets --user && jupyter nbextension enable --py declarativewidgets --user && jupyter serverextension enable --py declarativewidgets --user && jupyter declarativewidgets installr --library=/opt/conda/lib/R/library;
+server_4.2: INSTALL_DECLWID_CMD?=pip install --pre --upgrade toree && jupyter toree install --user; pip install --no-binary ::all: $$(ls -1 /src/dist/*.tar.gz | tail -n 1) && jupyter nbextension install --py declarativewidgets --user && jupyter nbextension enable --py declarativewidgets --user && jupyter serverextension enable --py declarativewidgets --user && jupyter declarativewidgets installr --library=/opt/conda/lib/R/library;
 server_4.2: SERVER_NAME?=urth_widgets_server
 server_4.2: OPTIONS?=-it --rm
 server_4.2: PORT_MAP?=-p 9500:8888

--- a/Makefile
+++ b/Makefile
@@ -338,7 +338,7 @@ _dev: .watch dist
 		-p 4040:4040 \
 		--user jovyan \
 		-e SPARK_OPTS="--master=local[4] --driver-java-options=-Dlog4j.logLevel=trace" \
-		-v `pwd`/dist/urth/widgets/ext/notebook:$(NB_HOME)/.local/share/jupyter/nbextensions/urth_widgets \
+		-v `pwd`/dist/declarativewidgets/static:$(NB_HOME)/.local/share/jupyter/nbextensions/declarativewidgets \
 		-v `pwd`/dist/urth:$(EXTENSION_DIR) \
 		-v `pwd`/etc:$(NB_HOME)/nbconfig \
 		-v `pwd`/etc/notebook.json:$(NB_HOME)/.jupyter/nbconfig/notebook.json \

--- a/README.md
+++ b/README.md
@@ -11,22 +11,22 @@ Watch from minute 21 to 41 of the [September 1st Jupyter meeting video recording
 * A base extension that enable the use of [Web Components](http://webcomponents.org) and [Polymer](https://www.polymer-project.org/1.0/) elements
 * A set of core elements facilitate interacting with code running on the kernel
 * Extensions to data binding support and installing of 3rd party elements.
-* Implementations for Python Kernel and Scala using [Apache Toree](https://github.com/apache/incubator-toree)
+* Implementations for Python, R (using [IRkernel](https://github.com/IRkernel/IRkernel)) and Scala (using [Apache Toree](https://github.com/apache/incubator-toree))
 
 ## What It Lacks
 
-* Support for state persistance and downstream tools (nbviewer)
+* Support for disconnected (no kernel) environments (i.e. nbviewer)
 * Interactions with DataFrames. Currently read-only.
 
 ## Runtime Requirements
 
-* Jupyter Notebook 4.0.x running on Python 3.x or Python 2.7.x (see the [0.1.x branch](https://github.com/jupyter-incubator/declarativewidgets/tree/0.1.x) for IPython Notebook 3.2.x compatibility)
-* [IPywidgets](https://github.com/ipython/ipywidgets) 4.1.x
+* Jupyter Notebook 4.0.x, 4.1.x, or 4.2.x running on Python 3.x or Python 2.7.x (see the [0.1.x branch](https://github.com/jupyter-incubator/declarativewidgets/tree/0.1.x) for IPython Notebook 3.2.x compatibility)
+* [IPywidgets](https://github.com/ipython/ipywidgets) 4.1.x and 5.0.x
 * Bower - Necessary for installing 3rd party elements straight out of notebook
-* Apache Toree for access to Spark using Scala
-* [R Kernel](https://github.com/IRkernel/IRkernel) for R language 
 
-Note: These are satisfied automatically when you follow the setup instructions below.
+##### Optional Requirements based on language support
+* Apache Toree for access to Spark using Scala
+* [IRkernel](https://github.com/IRkernel/IRkernel) for R language
 
 ##### Additional requirements for Python 2.7
 * `pip install futures==3.0.3`
@@ -37,6 +37,24 @@ We're running a tmpnb instance at [http://jupyter.cloudet.xyz](http://jupyter.cl
 
 ## Install It
 
+##### In Jupyter 4.2.x
+
+```bash
+# install the python package
+pip install jupyter_declarativewidgets
+
+# Install all parts of the extension to the active conda / venv / python env
+# and enable all parts of it in the jupyter profile in that environment
+# See jupyter declarativewidgets quick-setup --help for other options (e.g., --user)
+jupyter declarativewidgets quick-setup --sys-prefix
+# The above command is equivalent to this sequence of commands:
+# jupyter serverextension enable --py declarativewidgets --sys-prefix
+# jupyter nbextension install --py declarativewidgets --sys-prefix
+# jupyter nbextension enable --py declarativewidgets --sys-prefix
+```
+
+##### In Jupyter 4.0.x and 4.1.x
+
 ```bash
 # install the python package
 pip install jupyter_declarativewidgets
@@ -46,25 +64,57 @@ pip install jupyter_declarativewidgets
 jupyter declarativewidgets install --user --symlink --overwrite
 # enable the JS and server extensions in your ~/.jupyter
 jupyter declarativewidgets activate
+```
 
+##### Optional install of R support (all Jupyter versions)
+
+```bash
 # installing R support
 jupyter declarativewidgets installr --library path/to/r/libs
-
-# deactivate it later with
-jupyter declarativewidgets deactivate
 ``` 
 
-Restart your notebook server
+##### Note
+On all Jupyter versions, you will need to restart your notebook server if it was running during the enable/activate step. Also, note that you can run jupyter --paths to get a sense of where the extension files will be installed.
 
 ## Uninstall It
 
+##### In Jupyter 4.2.x
+
 ```bash
-jupyter declarativewidgets deactivate
+# Remove all parts of the extension from the active conda / venv / python env
+# See jupyter declarativewidgets quick-remove --help for other options (e.g., --user)
+jupyter declarativewidgets quick-remove --sys-prefix
+# The above command is equivalent to this sequence of commands:
+# jupyter bundler disable --py declarativewidgets --sys-prefix
+# jupyter nbextension disable --py declarativewidgets --sys-prefix
+# jupyter nbextension uninstall --py declarativewidgets --sys-prefix
+# jupyter serverextension disable --py declarativewidgets --sys-prefix
+
+# Remove the python package
 pip uninstall jupyter_declarativewidgets
 ```
 
-Note that there is no Jupyter method for removing the installed JavaScript extension assets. You will need to clean them up manually from your chosen install location.
- 
+##### In Jupyter 4.0.x and 4.1.x
+
+```bash
+# Disable extensions, but no way to remove frontend assets in this version
+jupyter declarativewidgets deactivate
+
+# Remove the python package
+pip uninstall jupyter_declarativewidgets
+```
+
+## Documentation
+
+The latest documentation can be found [here](http://jupyter-incubator.github.io/declarativewidgets/docs.html).
+
+Documentation is also available from within the notebook. To see the documentation add a cell with
+
+```html
+%%HTML
+<urth-help/>
+```
+
 ## Develop
 
 This repository is setup for a Dockerized development environment. On a Mac, do this one-time setup if you don't have a local Docker environment yet.
@@ -120,11 +170,11 @@ You can run a development environment against python 2.7 by adding an environmen
 PYTHON=python2 make dev
 ```
 
-## Build & Package
+### Build & Package
 
 Run `make sdist` to create a `pip` installable archive file in the `dist` directory. To test the package, run 'make server'. This command will run a docker container and pip install the package. It is useful to validate the packaging and installation. You should be able to install that tarball using pip anywhere you please with one caveat: the setup.py assumes you are installing to profile_default. There's no easy way to determine that you want to install against a different user at pip install time.
 
-## Test
+### Test
 
 On a Mac, `make test` will execute the browser, python and scala tests.
 
@@ -188,9 +238,7 @@ You can run a tests against python 2.7 by adding an environment variable to your
 PYTHON=python2 make test
 ```
 
-## Documentation
-
-The latest documentatio can be found [here](http://jupyter-incubator.github.io/declarativewidgets/docs.html).
+### Element Documentation
 
 Public elements and API are documented using [Polymer suggested guidelines](http://polymerelements.github.io/style-guide/).
 Documentation can be run locally with the `make docs` target:
@@ -206,6 +254,7 @@ Serving docs at http://127.0.0.1:4001
 
 Load the specified url in your browser to explore the documentation.
 
+## Other Topics
 ### Including a Web Component in a Notebook
 
 The Urth widgets framework provides a mechanism to easily install and import a web component into

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ Watch from minute 21 to 41 of the [September 1st Jupyter meeting video recording
 ## Runtime Requirements
 
 * Jupyter Notebook 4.0.x, 4.1.x, or 4.2.x running on Python 3.x or Python 2.7.x (see the [0.1.x branch](https://github.com/jupyter-incubator/declarativewidgets/tree/0.1.x) for IPython Notebook 3.2.x compatibility)
-* [IPywidgets](https://github.com/ipython/ipywidgets) 4.1.x and 5.0.x
+* [IPywidgets](https://github.com/ipython/ipywidgets) 4.1.x and 5.0.1+ (R and Scala support not available for 5.0.0)
 * Bower - Necessary for installing 3rd party elements straight out of notebook
 
 ##### Optional Requirements based on language support

--- a/elements/urth-help/urth-help.html
+++ b/elements/urth-help/urth-help.html
@@ -55,7 +55,7 @@ Creates a Polymer element that displays urth elements documentation page.
             },
             behaviors: [Urth.JupyterNotebookEnv],
             getDocUrl: function() {
-                return this._baseURL + "nbextensions/urth_widgets/docs/docs.html";
+                return this._baseURL + "nbextensions/declarativewidgets/docs/docs.html";
             }
         });
     })();

--- a/etc/notebook.json
+++ b/etc/notebook.json
@@ -1,5 +1,5 @@
 {
   "load_extensions": {
-    "urth_widgets/js/main": true
+    "declarativewidgets/js/main": true
   }
 }

--- a/etc/notebooks/examples/urth-scala-widgets.ipynb
+++ b/etc/notebooks/examples/urth-scala-widgets.ipynb
@@ -35,14 +35,14 @@
    "outputs": [],
    "source": [
     "// modify to IP and Port of this notebook server\n",
-    "%addjar http://localhost:8888/nbextensions/urth_widgets/urth-widgets.jar"
+    "%addjar http://localhost:8888/nbextensions/declarativewidgets/urth-widgets.jar"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
-    "collapsed": false
+    "collapsed": true
    },
    "outputs": [],
    "source": [
@@ -134,7 +134,7 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
-    "collapsed": false
+    "collapsed": true
    },
    "outputs": [],
    "source": [
@@ -169,7 +169,7 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
-    "collapsed": false
+    "collapsed": true
    },
    "outputs": [],
    "source": [
@@ -211,7 +211,7 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
-    "collapsed": false
+    "collapsed": true
    },
    "outputs": [],
    "source": [
@@ -248,7 +248,7 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
-    "collapsed": false
+    "collapsed": true
    },
    "outputs": [],
    "source": [
@@ -293,7 +293,7 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
-    "collapsed": false
+    "collapsed": true
    },
    "outputs": [],
    "source": [
@@ -336,7 +336,7 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
-    "collapsed": false
+    "collapsed": true
    },
    "outputs": [],
    "source": [
@@ -362,7 +362,7 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
-    "collapsed": false
+    "collapsed": true
    },
    "outputs": [],
    "source": [
@@ -371,9 +371,7 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {
-    "collapsed": true
-   },
+   "metadata": {},
    "source": [
     "#### Watch Item"
    ]
@@ -382,7 +380,7 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
-    "collapsed": false
+    "collapsed": true
    },
    "outputs": [],
    "source": [
@@ -417,7 +415,7 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
-    "collapsed": false
+    "collapsed": true
    },
    "outputs": [],
    "source": [
@@ -460,7 +458,7 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
-    "collapsed": false
+    "collapsed": true
    },
    "outputs": [],
    "source": [

--- a/etc/scripts/jupyter-declarativewidgets
+++ b/etc/scripts/jupyter-declarativewidgets
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 # Copyright (c) Jupyter Development Team.
 # Distributed under the terms of the Modified BSD License.
-import urth.widgets.ext.install.extensionapp
+import declarativewidgets.extensionapp
 
 if __name__ == '__main__':
-    urth.widgets.ext.install.extensionapp.main()
+    declarativewidgets.extensionapp.main()

--- a/kernel-r/declarativewidgets/R/widget.r
+++ b/kernel-r/declarativewidgets/R/widget.r
@@ -108,5 +108,10 @@ initWidgets <- function() {
     }
     library(IRkernel)
     comm_manager <- get("comm_manager", envir = as.environment("package:IRkernel"))()
+
+    # Support for ipywidgets 4.x client
     comm_manager$register_target("ipython.widget", target_handler)
+
+    # Support for ipywidgets 5.x client
+    comm_manager$register_target("jupyter.widget", target_handler)
 }

--- a/kernel-scala/src/main/scala/urth/widgets/package.scala
+++ b/kernel-scala/src/main/scala/urth/widgets/package.scala
@@ -80,10 +80,20 @@ package object widgets {
   private var _the_kernel: Kernel = _
 
   def initWidgets(implicit kernel: Kernel): Unit = {
-      val registrar = kernel.comm.register("ipython.widget")
-      registrar.addOpenHandler(Widget.openCallback)
-      registrar.addMsgHandler(Widget.msgCallback)
-      _the_kernel = kernel
+    /*
+     * Support for ipywidget 4.x Client
+     */
+    kernel.comm.register("ipython.widget")
+      .addOpenHandler(Widget.openCallback)
+      .addMsgHandler(Widget.msgCallback)
+
+    /*
+     * Support for ipywidget 5.x Client
+     */
+    kernel.comm.register("jupyter.widget")
+      .addOpenHandler(Widget.openCallback)
+      .addMsgHandler(Widget.msgCallback)
+    _the_kernel = kernel
   }
 
   def getKernel: Kernel = {

--- a/nb-extension/js/main.js
+++ b/nb-extension/js/main.js
@@ -15,9 +15,9 @@ define([
     requirejs.config({
         map: {
             '*': {
-                'jupyter-decl-widgets': 'nbextensions/urth_widgets/js/widgets'
+                'jupyter-decl-widgets': 'nbextensions/declarativewidgets/js/widgets'
             },
-            'nbextensions/urth_widgets/js/widgets': {
+            'nbextensions/declarativewidgets/js/widgets': {
                 'jupyter-js-widgets': 'ipywidgets4-or-jupyter-js-widgets'
             }
         },

--- a/nb-extension/python/declarativewidgets/__init__.py
+++ b/nb-extension/python/declarativewidgets/__init__.py
@@ -1,0 +1,17 @@
+# Copyright (c) Jupyter Development Team.
+# Distributed under the terms of the Modified BSD License.
+
+def _jupyter_nbextension_paths():
+    '''API for JS extension installation on notebook 4.2'''
+    return [{
+        'section': 'notebook',
+        'src': '../urth/widgets/ext/notebook',
+        'dest': 'urth_widgets',
+        'require': 'urth_widgets/js/main'
+    }]
+
+def _jupyter_server_extension_paths():
+    '''API for server extension installation on notebook 4.2'''
+    return [{
+        "module": "urth.widgets.ext.urth_import"
+    }]

--- a/nb-extension/python/declarativewidgets/__init__.py
+++ b/nb-extension/python/declarativewidgets/__init__.py
@@ -5,7 +5,7 @@ def _jupyter_nbextension_paths():
     '''API for JS extension installation on notebook 4.2'''
     return [{
         'section': 'notebook',
-        'src': '../urth/widgets/ext/notebook',
+        'src': 'static',
         'dest': 'urth_widgets',
         'require': 'urth_widgets/js/main'
     }]

--- a/nb-extension/python/declarativewidgets/__init__.py
+++ b/nb-extension/python/declarativewidgets/__init__.py
@@ -6,8 +6,8 @@ def _jupyter_nbextension_paths():
     return [{
         'section': 'notebook',
         'src': 'static',
-        'dest': 'urth_widgets',
-        'require': 'urth_widgets/js/main'
+        'dest': 'declarativewidgets',
+        'require': 'declarativewidgets/js/main'
     }]
 
 def _jupyter_server_extension_paths():

--- a/nb-extension/python/declarativewidgets/extensionapp.py
+++ b/nb-extension/python/declarativewidgets/extensionapp.py
@@ -89,7 +89,7 @@ class ExtensionInstallApp(InstallNBExtensionApp):
 
         self.log.info("Installing jupyter_declarativewidgets notebook extensions")
         self.extra_args = [os.path.join(here, 'static')]
-        self.destination = 'urth_widgets'  # TODO: must change to jupyter_declarativewidgets
+        self.destination = 'declarativewidgets'
         self.install_extensions()
 
 
@@ -129,7 +129,7 @@ class ExtensionActivateApp(EnableNBExtensionApp):
 
         self.log.info("Activating jupyter_declarativewidgets JS notebook extensions")
         self.section = "notebook"
-        self.enable_nbextension("urth_widgets/js/main")
+        self.enable_nbextension("declarativewidgets/js/main")
 
         self.log.info("Done. You may need to restart the Jupyter notebook server for changes to take effect.")
 
@@ -177,7 +177,7 @@ class ExtensionDeactivateApp(DisableNBExtensionApp):
 
         self.log.info("Deactivating jupyter_declarativewidgets JS notebook extensions")
         self.section = "notebook"
-        self.disable_nbextension("urth_widgets/js/main")
+        self.disable_nbextension("declarativewidgets/js/main")
 
         self.log.info("Done. You may need to restart the Jupyter notebook server for changes to take effect.")
 

--- a/nb-extension/python/declarativewidgets/extensionapp.py
+++ b/nb-extension/python/declarativewidgets/extensionapp.py
@@ -60,7 +60,7 @@ class ExtensionInstallRApp(InstallNBExtensionApp):
             extra_r_options = "-l {}".format(self.library)
 
         here = os.path.abspath(os.path.join(os.path.dirname(__file__)))
-        extension_path = os.path.join(here, '../urth/widgets/ext/notebook')
+        extension_path = os.path.join(here, 'static')
         subprocess.call("R CMD INSTALL {0} {1}/urth-widgets.tgz".format(extra_r_options, extension_path), shell=True)
 
 
@@ -88,7 +88,7 @@ class ExtensionInstallApp(InstallNBExtensionApp):
         here = os.path.abspath(os.path.join(os.path.dirname(__file__)))
 
         self.log.info("Installing jupyter_declarativewidgets notebook extensions")
-        self.extra_args = [os.path.join(here, '../urth/widgets/ext/notebook')]
+        self.extra_args = [os.path.join(here, 'static')]
         self.destination = 'urth_widgets'  # TODO: must change to jupyter_declarativewidgets
         self.install_extensions()
 

--- a/nb-extension/python/declarativewidgets/extensionapp.py
+++ b/nb-extension/python/declarativewidgets/extensionapp.py
@@ -60,7 +60,7 @@ class ExtensionInstallRApp(InstallNBExtensionApp):
             extra_r_options = "-l {}".format(self.library)
 
         here = os.path.abspath(os.path.join(os.path.dirname(__file__)))
-        extension_path = os.path.join(here, '../notebook')
+        extension_path = os.path.join(here, '../urth/widgets/ext/notebook')
         subprocess.call("R CMD INSTALL {0} {1}/urth-widgets.tgz".format(extra_r_options, extension_path), shell=True)
 
 
@@ -88,7 +88,7 @@ class ExtensionInstallApp(InstallNBExtensionApp):
         here = os.path.abspath(os.path.join(os.path.dirname(__file__)))
 
         self.log.info("Installing jupyter_declarativewidgets notebook extensions")
-        self.extra_args = [os.path.join(here, '../notebook')]
+        self.extra_args = [os.path.join(here, '../urth/widgets/ext/notebook')]
         self.destination = 'urth_widgets'  # TODO: must change to jupyter_declarativewidgets
         self.install_extensions()
 

--- a/nb-extension/python/urth/widgets/ext/install/__init__.py
+++ b/nb-extension/python/urth/widgets/ext/install/__init__.py
@@ -1,2 +1,0 @@
-# Copyright (c) Jupyter Development Team.
-# Distributed under the terms of the Modified BSD License.

--- a/nb-extension/python/urth/widgets/ext/urth_import.py
+++ b/nb-extension/python/urth/widgets/ext/urth_import.py
@@ -8,7 +8,7 @@ import subprocess
 
 from notebook.utils import url_path_join
 from notebook.base.handlers import FileFindHandler
-from jupyter_core.paths import jupyter_data_dir
+from jupyter_core.paths import jupyter_path
 from tornado.web import HTTPError, RequestHandler
 from concurrent.futures import ThreadPoolExecutor
 
@@ -81,13 +81,8 @@ def load_jupyter_server_extension(nb_app):
     logger = nb_app.log
     logger.info('Loading urth_import server extension.')
 
-    # Determine the nbextensions directory and urth_widgets path
-    ipython_dir = jupyter_data_dir()
     web_app = nb_app.web_app
-    for path in web_app.settings['nbextensions_path']:
-        if ipython_dir in path:
-            nbext = path
-    widgets_dir = os.path.join(nbext, 'declarativewidgets/')
+    widgets_dir = get_nbextension_path()
 
     # Write out a .bowerrc file to configure bower installs to
     # not be interactive and not to prompt for analytics
@@ -114,3 +109,9 @@ def load_jupyter_server_extension(nb_app):
         (import_route_pattern, UrthImportHandler, dict(executor=ThreadPoolExecutor(max_workers=1))),
         (components_route_pattern, FileFindHandler, {'path': [components_path]})
     ])
+
+def get_nbextension_path():
+    """Find the path to the declarativewidgets nbextension"""
+    for abspath in jupyter_path('nbextensions', 'declarativewidgets'):
+        if os.path.exists(abspath):
+            return abspath

--- a/nb-extension/python/urth/widgets/ext/urth_import.py
+++ b/nb-extension/python/urth/widgets/ext/urth_import.py
@@ -87,7 +87,7 @@ def load_jupyter_server_extension(nb_app):
     for path in web_app.settings['nbextensions_path']:
         if ipython_dir in path:
             nbext = path
-    widgets_dir = os.path.join(nbext, 'urth_widgets/')
+    widgets_dir = os.path.join(nbext, 'declarativewidgets/')
 
     # Write out a .bowerrc file to configure bower installs to
     # not be interactive and not to prompt for analytics

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "polybuild": "polybuild",
     "test": "wct elements/*/test",
     "test-sauce": "wct --skip-plugin local --plugin sauce elements/*/test",
-    "system-test": "node_modules/mocha/bin/mocha system-test/*-specs.js --timeout 500000 --reporter spec",
+    "system-test": "node_modules/mocha/bin/mocha --timeout 500000 --reporter spec",
     "watch": "gulp watch",
     "watch-docs": "gulp watch-docs"
   },

--- a/setup.py
+++ b/setup.py
@@ -47,7 +47,7 @@ if 'setuptools' in sys.modules:
     # setupstools turns entrypoint scripts into executables on windows
     setup_args['entry_points'] = {
         'console_scripts': [
-            'jupyter-declarativewidgets = urth.widgets.ext.install.extensionapp:main'
+            'jupyter-declarativewidgets = declarativewidgets.extensionapp:main'
         ]
     }
     # Don't bother installing the .py scripts if if we're using entrypoints

--- a/system-test/urth-system-test-specs.js
+++ b/system-test/urth-system-test-specs.js
@@ -71,7 +71,7 @@ describe('Widgets System Test', function() {
 
     it('should render ipywidget when using urth-viz-ipywidget', function(done) {
 
-        var ipySlider = '#ipywid .widget-slider';
+        var ipySlider = '#ipywid .widget-hslider';
 
         boilerplate.browser
             .waitForElementsByCssSelector(ipySlider, wd.asserters.isDisplayed, 10000)


### PR DESCRIPTION
resolves #304 

Items covered by this PR
- [x] Add support to install using Jupyter 4.2 mode
- [x] Update Readme with new version support and options to install
- [x] Fix issue in urth_import module re: not finding the .bowerrc file when installed using `--sys-prefix`
- [x] Add support in R and Scala widget support to listen to new `jupyter.widget` target name
- [x] Create shortcuts for installation based on [quick-setup](https://github.com/jupyter-incubator/contentmanagement#install-it)
- [x] Enable system testing to test new Jup/ipywidgets (currently failing)
