### PR TITLE
Use firefox instead of chrome for pull request unit testing.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -226,7 +226,7 @@ ifdef SAUCE_USER_NAME
 	@echo 'Running web component tests remotely on Sauce Labs...'
 	@npm run test-sauce --silent -- --sauce-tunnel-id \"$(TRAVIS_JOB_NUMBER)\" --sauce-username $(SAUCE_USER_NAME) --sauce-access-key $(SAUCE_ACCESS_KEY)
 else
-	@npm run test -- --local chrome
+	@npm run test -- --local firefox
 endif
 
 test-py: dist/urth


### PR DESCRIPTION
Travis image has a back level version of Chrome (46) that is causing unit tests on pull requests to fail with the following error:

`Failed to execute 'animate' on 'Element': The provided value is not of type '(EffectModel or sequence<Dictionary>)'`

This is apparently due to a conflict between Chrome 46 and `web-animations-js` `2.2.0`. Moving the pull request unit tests to firefox to get pass the unit test failure.
