### PR TITLE
Protect against a potential timing error in the model creation logic

### DIFF
--- a/elements/urth-core-behaviors/jupyter-widget-behavior.html
+++ b/elements/urth-core-behaviors/jupyter-widget-behavior.html
@@ -52,6 +52,13 @@ This behavior is used to encapsulate some of the services needed for ipywidgets.
                         widget_class: this.kernelClass
                     }
                 ).then(function(model) {
+                        //This check is to protect against a timing in ipywidgets where the comm can be close
+                        //by the time it gets to resolve this promise
+                        if(!model.comm.kernel.comm_manager.comms[model.comm.comm_id]){
+                            this._handleCommDisconnect();
+                            return;
+                        }
+
                         console.log('Model creation successful!', model);
                         this.__modelChangeCallback = this._onModelChange.bind(this);
                         this.__commCloseCallback = this._handleCommDisconnect.bind(this);


### PR DESCRIPTION
The problem was due to the following:
- Call to `widget_manager.new_widget(...).then(function(model){...})`
- The call to new_widget is what opens the comm with `jupyter.widgets`
- There is no handler for the target name in the kernel (R, Scala) yet, so it closes the comm
- The comm close is handled on the browser side before the WidgetModel is create and passed to the callback above
- If in my callback I want to respond to `model.once("comm:close")` it is too late

This PR is protecting in the callback and checking if the model's comm is still registered in the CommManager. This give me a chance to kick off the retry logic directly.
