### PR TITLE
Added support for urth-core-function to listen to click events

### DIFF
--- a/elements/urth-core-function/urth-core-function.html
+++ b/elements/urth-core-function/urth-core-function.html
@@ -27,6 +27,9 @@ Both examples are equivalent to invoking `aFunction(x=5, y=4)`
  2. By setting the `auto` property and it automatically invokes when parameters set
  3. By handling the `click` event of a child element. For example, just placing a `button` inside this element.
 
+
+Note that when using the 'click' event approach described above in #3, a click on any child will trigger an invocation.
+
 @group Urth Core
 @element urth-core-function
 -->

--- a/elements/urth-core-function/urth-core-function.html
+++ b/elements/urth-core-function/urth-core-function.html
@@ -21,7 +21,11 @@ The elements allows setting parameters in 2 ways:
 
 Both examples are equivalent to invoking `aFunction(x=5, y=4)`
 
-`urth-core-function` also provides an `invoke` method. This method can be used to force an invocation of the function.
+`urth-core-function` will invoke in the following ways:
+
+ 1. By calling the `invoke` method using Javascript
+ 2. By setting the `auto` property and it automatically invokes when parameters set
+ 3. By handling the `click` event of a child element. For example, just placing a `button` inside this element.
 
 @group Urth Core
 @element urth-core-function
@@ -133,7 +137,8 @@ Both examples are equivalent to invoking `aFunction(x=5, y=4)`
             ],
 
             listeners: {
-                'watch_notify': 'invoke'
+                'watch_notify': 'invoke',
+                'click': '_tryInvoke'
             },
 
             created: function(){

--- a/etc/notebooks/examples/urth-core-function.ipynb
+++ b/etc/notebooks/examples/urth-core-function.ipynb
@@ -59,7 +59,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "### Example 1: Single parameter function"
+    "### Example 1a: Single parameter function"
    ]
   },
   {
@@ -104,7 +104,7 @@
    "source": [
     "%%html\n",
     "<template is=\"dom-bind\">\n",
-    "    <urth-core-function id=\"f1\" ref=\"aFunction\" arg-x=\"{{x}}\" auto></urth-core-function>\n",
+    "    <urth-core-function id=\"f1a\" ref=\"aFunction\" arg-x=\"{{x}}\" auto></urth-core-function>\n",
     "    \n",
     "    <form onSubmit=\"return false;\">\n",
     "        <label>x:</label>\n",
@@ -118,7 +118,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "### Example 2: Multi parameter function"
+    "### Example 1b: Multi parameter function"
    ]
   },
   {
@@ -160,15 +160,15 @@
    "outputs": [],
    "source": [
     "%%html\n",
-    "<urth-core-function id=\"f2\" ref=\"aFunctionWithTwoArgs\" arg-x=\"0.5\" arg-y=\"4\"></urth-core-function>\n",
-    "<button onClick=\"f2.invoke()\">invoke</button>"
+    "<urth-core-function id=\"f1b\" ref=\"aFunctionWithTwoArgs\" arg-x=\"0.5\" arg-y=\"4\"></urth-core-function>\n",
+    "<button onClick=\"f1b.invoke()\">invoke</button>"
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "### Example 3: Function with optional argument"
+    "### Example 1c: Function with optional argument"
    ]
   },
   {
@@ -210,15 +210,15 @@
    "outputs": [],
    "source": [
     "%%html\n",
-    "<urth-core-function id=\"f3\" ref=\"aFunctionWithOptionalArgs\" arg-x=\"0.5\"></urth-core-function>\n",
-    "<button onClick=\"f3.invoke()\">invoke</button>"
+    "<urth-core-function id=\"f1c\" ref=\"aFunctionWithOptionalArgs\" arg-x=\"0.5\"></urth-core-function>\n",
+    "<button onClick=\"f1c.invoke()\">invoke</button>"
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "### Example 3b Function with boolean parameter"
+    "### Example 1d Function with boolean parameter"
    ]
   },
   {
@@ -243,7 +243,7 @@
    "source": [
     "%%html\n",
     "<template is=\"dom-bind\">\n",
-    "    <urth-core-function id=\"f3b\" ref=\"aFunctionWithBoolean\" arg-b=\"{{checked}}\" result=\"{{res}}\" auto></urth-core-function>\n",
+    "    <urth-core-function id=\"f1d\" ref=\"aFunctionWithBoolean\" arg-b=\"{{checked}}\" result=\"{{res}}\" auto></urth-core-function>\n",
     "    <paper-toggle-button checked=\"{{checked}}\"></paper-toggle-button>\n",
     "    <span>{{res}}</span> World\n",
     "</template>"
@@ -253,7 +253,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "### Example 3c Function with List parameter\n",
+    "### Example 1e Function with List parameter\n",
     "This function will be invoked when the elements of the lists are changed. Change the elements in the list by selecting from the list below."
    ]
   },
@@ -293,8 +293,8 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "### Example 4a: Using the 'args' property without 'auto'\n",
-    "Changing the values in the input boxes with not invoke the function. Must click `invoke` button to call the function. Notice also that the button will not work unless the function is ready to invoke. This is `true` when the signature of the function is known and all required parameters are set."
+    "### Example 2a: Explicitly invoking a function\n",
+    "Changing the values in the input boxes with not invoke the function. Must click `invoke` button to call the function. The button calls the `invoke` function of `urth-core-function`. Notice also that the button will not work unless the function is ready to invoke. This is `true` when the signature of the function is known and all required parameters are set."
    ]
   },
   {
@@ -337,10 +337,10 @@
    "source": [
     "%%html\n",
     "<template is=\"dom-bind\">\n",
-    "    <urth-core-function id=\"f4a\" ref=\"aFunctionWithOptionalArgs2\" is-ready=\"{{isready}}\" args=\"{{args}}\"></urth-core-function>\n",
+    "    <urth-core-function id=\"f2a\" ref=\"aFunctionWithOptionalArgs2\" is-ready=\"{{isready}}\" args=\"{{args}}\"></urth-core-function>\n",
     "    x: <input type=\"text\" value=\"{{args.x::change}}\"></input>\n",
     "    y: <input type=\"text\" value=\"{{args.y::change}}\"></input>\n",
-    "    <button disabled={{!isready}} onClick=\"f4a.invoke()\">invoke</button>\n",
+    "    <button disabled={{!isready}} onClick=\"f2a.invoke()\">invoke</button>\n",
     "    Ready: <span>{{isready}}</span>\n",
     "</template>"
    ]
@@ -349,8 +349,8 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "### Example 4b: Using the 'args' property with 'auto'\n",
-    "Changing the values on the input boxes and pressing enter or focusing out, will invoke the funtion automatically."
+    "### Example 2b: Automatically invoking function\n",
+    "Changing the values on the input boxes and pressing enter or focusing out, will invoke the function automatically. This is enabled by the `auto` property. Once the `urth-core-function` detects that all the parameters are properly set, it will invoke itself. Changes to any of the parameters will also cause an invocation."
    ]
   },
   {
@@ -363,7 +363,7 @@
    "source": [
     "%%html\n",
     "<template is=\"dom-bind\">\n",
-    "    <urth-core-function id=\"f4b\" ref=\"aFunctionWithOptionalArgs2\" args=\"{{args}}\" auto></urth-core-function>\n",
+    "    <urth-core-function id=\"f2b\" ref=\"aFunctionWithOptionalArgs2\" args=\"{{args}}\" auto></urth-core-function>\n",
     "    x: <input type=\"text\" value=\"{{args.x::change}}\"></input>\n",
     "    y: <input type=\"text\" value=\"{{args.y::change}}\"></input>\n",
     "</template>"
@@ -373,7 +373,33 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "### Example 5a: Using a function's return value"
+    "### Example 2c: Handling onclick events of children\n",
+    "If an element that fires an `onclick` event is places inside the `urth-core-function` element, it will trigger an invocation."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "%%html\n",
+    "<template is=\"dom-bind\">\n",
+    "    x: <input type=\"text\" value=\"{{args.x::change}}\"></input>\n",
+    "    y: <input type=\"text\" value=\"{{args.y::change}}\"></input>\n",
+    "    <urth-core-function id=\"f2c\" ref=\"aFunctionWithOptionalArgs2\" args=\"{{args}}\">\n",
+    "        <button>invoke</button>\n",
+    "    </urth-core-function>\n",
+    "</template>"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Example 3a: Using a function's return value"
    ]
   },
   {
@@ -398,7 +424,7 @@
    "source": [
     "%%html\n",
     "<template is=\"dom-bind\">\n",
-    "    <urth-core-function id=\"f5\" ref=\"aMathFunction\" arg-x=\"{{x}}\" result=\"{{y}}\" auto></urth-core-function>\n",
+    "    <urth-core-function id=\"f3a\" ref=\"aMathFunction\" arg-x=\"{{x}}\" result=\"{{y}}\" auto></urth-core-function>\n",
     "    <paper-slider min=\"0\" max=\"100\" step=\"1\" value=\"{{x}}\"></paper-slider>\n",
     "    <span>{{y}}</span>\n",
     "</template>"
@@ -410,7 +436,7 @@
     "collapsed": true
    },
    "source": [
-    "### Example 5b: Function returning a Plot\n",
+    "### Example 3b: Function returning a Plot\n",
     "\n",
     "The `matplotlib.pyplot.Figure` object returned by the plot function will get automatically serialized into a base64 image string.\n",
     "\n",
@@ -454,7 +480,7 @@
    "source": [
     "%%html\n",
     "<template is=\"dom-bind\">\n",
-    "    <urth-core-function id=\"f5b\" ref=\"aPlotFunction\" arg-noise=\"{{noise}}\" result=\"{{plot}}\" auto></urth-core-function>\n",
+    "    <urth-core-function id=\"f3b\" ref=\"aPlotFunction\" arg-noise=\"{{noise}}\" result=\"{{plot}}\" auto></urth-core-function>\n",
     "    \n",
     "    noise<paper-slider min=\"0\" max=\"5\" step=\"0.5\" value=\"{{noise}}\"></paper-slider>\n",
     "    \n",
@@ -466,7 +492,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "### Example 5c: Function returning a pandas Series"
+    "### Example 3c: Function returning a pandas Series"
    ]
   },
   {
@@ -499,10 +525,10 @@
    "source": [
     "%%html\n",
     "<template is=\"dom-bind\">\n",
-    "    <urth-core-function id=\"f5c\" ref=\"aPandasSeriesFunction\" arg-n=\"{{n}}\" result=\"{{s}}\"></urth-core-function>\n",
+    "    <urth-core-function id=\"f3c\" ref=\"aPandasSeriesFunction\" arg-n=\"{{n}}\" result=\"{{s}}\"></urth-core-function>\n",
     "    \n",
     "    n<paper-slider min=\"1\" max=\"3\" step=\"1\" value=\"{{n}}\"></paper-slider>\n",
-    "    <button onClick=\"f5c.invoke()\">invoke</button>\n",
+    "    <button onClick=\"f3c.invoke()\">invoke</button>\n",
     "    \n",
     "    <p>a: <span>{{s.a}}</span></p>\n",
     "    <p>b: <span>{{s.b}}</span></p>\n",
@@ -514,7 +540,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "### Example 5d: Function returning a pandas DataFrame"
+    "### Example 3d: Function returning a pandas DataFrame"
    ]
   },
   {
@@ -543,11 +569,11 @@
    "source": [
     "%%html\n",
     "<template is=\"dom-bind\">\n",
-    "    <urth-core-function id=\"f5d\" ref=\"aDataFrameFunction\" arg-rows=\"{{rows}}\" arg-cols=\"{{cols}}\" result=\"{{df}}\"></urth-core-function>\n",
+    "    <urth-core-function id=\"f3d\" ref=\"aDataFrameFunction\" arg-rows=\"{{rows}}\" arg-cols=\"{{cols}}\" result=\"{{df}}\"></urth-core-function>\n",
     "    \n",
     "    rows<paper-slider min=\"1\" max=\"10\" step=\"1\" value=\"{{rows}}\"></paper-slider>\n",
     "    cols<paper-slider min=\"1\" max=\"10\" step=\"1\" value=\"{{cols}}\"></paper-slider>\n",
-    "    <button onClick=\"f5d.invoke()\">invoke</button>\n",
+    "    <button onClick=\"f3d.invoke()\">invoke</button>\n",
     "    \n",
     "    <p>columns: <span>{{df.columns}}</span></p>\n",
     "    <p>index: <span>{{df.index}}</span></p>\n",
@@ -559,14 +585,14 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "### Example 5e: Function returning a Spark Dataframe"
+    "### Example 3e: Function returning a Spark Dataframe"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
-    "collapsed": true
+    "collapsed": false
    },
    "outputs": [],
    "source": [
@@ -599,11 +625,11 @@
    "source": [
     "%%html\n",
     "<template is=\"dom-bind\">\n",
-    "    <urth-core-function id=\"f5e\" ref=\"aSparkDataFrameFunction\" limit=\"3\" arg-rows=\"{{rows}}\" arg-cols=\"{{cols}}\" result=\"{{df}}\"></urth-core-function>\n",
+    "    <urth-core-function id=\"f3e\" ref=\"aSparkDataFrameFunction\" limit=\"3\" arg-rows=\"{{rows}}\" arg-cols=\"{{cols}}\" result=\"{{df}}\"></urth-core-function>\n",
     "    \n",
     "    rows<paper-slider min=\"1\" max=\"10\" step=\"1\" value=\"{{rows}}\"></paper-slider>\n",
     "    cols<paper-slider min=\"1\" max=\"10\" step=\"1\" value=\"{{cols}}\"></paper-slider>\n",
-    "    <button onClick=\"f5e.invoke()\">invoke</button>\n",
+    "    <button onClick=\"f3e.invoke()\">invoke</button>\n",
     "    \n",
     "    <p>columns: <span>{{df.columns}}</span></p>\n",
     "    <p>index: <span>{{df.index}}</span></p>\n",
@@ -615,7 +641,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "### Example 5f: Function returning a custom class. Defining a custom serializer\n",
+    "### Example 3f: Function returning a custom class. Defining a custom serializer\n",
     "\n",
     "In this example, we have a function that returns a custom type `Foo`. We would like to serialize the `Foo` that's returned so that the value is useful for other widgets."
    ]
@@ -705,8 +731,8 @@
    "source": [
     "%%html\n",
     "<template is=\"dom-bind\">\n",
-    "    <urth-core-function id=\"f5f\" ref=\"aFooFunction\" result=\"{{r}}\"></urth-core-function>\n",
-    "    <button onClick=\"f5f.invoke()\">invoke</button>    \n",
+    "    <urth-core-function id=\"f3f\" ref=\"aFooFunction\" result=\"{{r}}\"></urth-core-function>\n",
+    "    <button onClick=\"f3f.invoke()\">invoke</button>    \n",
     "    <span>{{r}}</span>\n",
     "</template>"
    ]
@@ -715,7 +741,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "### Example 5g: Function returning an object consisting of non-serializeable types\n",
+    "### Example 3g: Function returning an object consisting of non-serializeable types\n",
     "\n",
     "If you invoke a function that returns a Python object, then the object must be JSON serializable, which means that the object and it attributes or items must be reduced to basic Python types such as list, dict, int, float, str, etc.  The function below returns a dict whose item values are _not_ JSON serializable."
    ]
@@ -783,8 +809,8 @@
    "source": [
     "%%html\n",
     "<template is=\"dom-bind\">\n",
-    "    <urth-core-function id=\"f5g\" ref=\"nonSerializeableTypes\" result=\"{{d}}\"></urth-core-function>\n",
-    "    <button onClick=\"f5g.invoke()\">invoke</button>    \n",
+    "    <urth-core-function id=\"f3g\" ref=\"nonSerializeableTypes\" result=\"{{d}}\"></urth-core-function>\n",
+    "    <button onClick=\"f3g.invoke()\">invoke</button>    \n",
     "    <span>{{d}}</span>\n",
     "</template>"
    ]
@@ -861,8 +887,8 @@
    "source": [
     "%%html\n",
     "<template is=\"dom-bind\">\n",
-    "    <urth-core-function id=\"f5gs\" ref=\"serializableTypes\" result=\"{{d}}\"></urth-core-function>\n",
-    "    <button onClick=\"f5gs.invoke()\">invoke</button>    \n",
+    "    <urth-core-function id=\"f3gs\" ref=\"serializableTypes\" result=\"{{d}}\"></urth-core-function>\n",
+    "    <button onClick=\"f3gs.invoke()\">invoke</button>    \n",
     "    <p>date: <span>{{d.date}}</span></p>\n",
     "    <p>datetime: <span>{{d.datetime}}</span></p>\n",
     "    <p>nat: <span>{{d.nat}}</span></p>\n",
@@ -877,7 +903,7 @@
     "collapsed": true
    },
    "source": [
-    "### Example 6: Automatically converting arguments to correct types\n",
+    "### Example 4: Automatically converting arguments to correct types\n",
     "\n",
     "The frontend sends argument values as strings. The backend will convert the\n",
     "arguments to their proper types if possible. Argument types can be indicated by:\n",
@@ -889,7 +915,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "#### Example 6a: Default Argument\n",
+    "#### Example 4a: Default Argument\n",
     "\n",
     "`iters` will be considered an `int` and `x` will be considered a `float` based on the default arguments. Since there is no default or annotation for `msg`, it will not be converted."
    ]
@@ -913,13 +939,13 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
-    "collapsed": true
+    "collapsed": false
    },
    "outputs": [],
    "source": [
     "%%html\n",
     "<template is=\"dom-bind\">\n",
-    "    <urth-core-function id=\"f6a\" ref=\"aMathFunction2\" arg-msg=\"the output is\" arg-iters=\"{{iters}}\" arg-x=\"{{x}}\" result=\"{{y}}\" auto></urth-core-function>\n",
+    "    <urth-core-function id=\"f4a\" ref=\"aMathFunction2\" arg-msg=\"the output is\" arg-iters=\"{{iters}}\" arg-x=\"{{x}}\" result=\"{{y}}\" auto></urth-core-function>\n",
     "    iters: <paper-slider min=\"0\" max=\"10\" step=\"1\" value=\"{{iters}}\"></paper-slider>\n",
     "    x: <paper-slider min=\"0\" max=\"10\" step=\"0.1\" value=\"{{x}}\"></paper-slider>\n",
     "    <p>{{y}}</p>\n",
@@ -930,7 +956,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "#### Example 6b: Annotation\n",
+    "#### Example 4b: Annotation\n",
     "\n",
     "`iters` will be considered an int and `x` will be considered a `float` based on annotations"
    ]
@@ -963,13 +989,13 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
-    "collapsed": true
+    "collapsed": false
    },
    "outputs": [],
    "source": [
     "%%html\n",
     "<template is=\"dom-bind\">\n",
-    "    <urth-core-function id=\"f6b\" ref=\"aMathFunction3\" arg-iters=\"{{iters}}\" arg-x=\"{{x}}\" result=\"{{y}}\" auto></urth-core-function>\n",
+    "    <urth-core-function id=\"f4b\" ref=\"aMathFunction3\" arg-iters=\"{{iters}}\" arg-x=\"{{x}}\" result=\"{{y}}\" auto></urth-core-function>\n",
     "    iters: <paper-slider min=\"0\" max=\"10\" step=\"1\" value=\"{{iters}}\"></paper-slider>\n",
     "    x: <paper-slider min=\"0\" max=\"10\" step=\"0.1\" value=\"{{x}}\"></paper-slider>\n",
     "    <p>{{y}}</p>\n",
@@ -982,7 +1008,7 @@
     "collapsed": true
    },
    "source": [
-    "### Example 7: Debounce function invocation\n",
+    "### Example 5: Debounce function invocation\n",
     "When using auto, there may be the need to debounce the invocation of a function. This can facilitate waiting for users to complete input or protect against multiple accidental/malicious invocations in a short time frame. \n",
     "\n",
     "The example below has a function which will return the number of times it is invoked. The `urth-core-function` element has a debounce time of `2000` milliseconds which will prevent multiple invocations when rapidly pressing the _Invoke Function_ button."
@@ -1007,17 +1033,26 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
-    "collapsed": true
+    "collapsed": false
    },
    "outputs": [],
    "source": [
     "%%html\n",
     "<template is=\"dom-bind\">\n",
-    "    <urth-core-function id=\"f7\" ref=\"aDebouncedFunction1\" delay='2000' result=\"{{invocations}}\" auto></urth-core-function>\n",
-    "    <button onclick='f7.invoke()'>Invoke Function</button>\n",
+    "    <urth-core-function id=\"f5\" ref=\"aDebouncedFunction1\" delay='2000' result=\"{{invocations}}\" auto></urth-core-function>\n",
+    "    <button onclick='f5.invoke()'>Invoke Function</button>\n",
     "    <p>Invocations: <span>{{invocations}}</span></p>\n",
     "</template>"
    ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": []
   }
  ],
  "metadata": {
@@ -1042,7 +1077,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.4.4"
+   "version": "3.5.1"
   }
  },
  "nbformat": 4,

--- a/etc/notebooks/examples/urth-core-function.ipynb
+++ b/etc/notebooks/examples/urth-core-function.ipynb
@@ -378,6 +378,15 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "<div class=\"alert alert-info\" role=\"alert\" style=\"margin-top: 10px\">\n",
+    "<p><strong>Note:</strong> When using this approach, a click on any child will trigger an invocation.</p>\n",
+    "</div>"
+   ]
+  },
+  {
    "cell_type": "code",
    "execution_count": null,
    "metadata": {


### PR DESCRIPTION
Can't believe that I did not think of this earlier, but this PR allows adding a child inside the `urth-core-function` that fires `click` events. The `urth-core-function` will listen to the click events automatically and invoke itself when it sees it.

Example 2c in `examples/urth-core-function.ipynb` demonstrates the new capability.
