### PR TITLE
Fix undefined ref to model.comm.kernel outside notebook

### DIFF
--- a/elements/urth-core-behaviors/jupyter-widget-behavior.html
+++ b/elements/urth-core-behaviors/jupyter-widget-behavior.html
@@ -54,7 +54,7 @@ This behavior is used to encapsulate some of the services needed for ipywidgets.
                 ).then(function(model) {
                         //This check is to protect against a timing in ipywidgets where the comm can be close
                         //by the time it gets to resolve this promise
-                        if(!model.comm.kernel.comm_manager.comms[model.comm.comm_id]){
+                        if(model.comm && !model.comm.kernel.comm_manager.comms[model.comm.comm_id]){
                             this._handleCommDisconnect();
                             return;
                         }


### PR DESCRIPTION
See jupyter-incubator/dashboards_server#193

The ipywidgets shim for jupyter-js-services does not have
a kernel ref, and a  kernel doesn't always have a comm manager
so guard this hack-check in case widgets are used in non-notebook
environments (e.g., dashboard server).

Ordinarily, I'd say the container (dashboard server) should shim, but this is a really, really deep ref and a hack as it is to handle a ipywidgets bug.
