### PR TITLE
Fix API for non-notebook environments

### DIFF
--- a/nb-extension/js/init/init.js
+++ b/nb-extension/js/init/init.js
@@ -154,6 +154,8 @@ define([
             // optional `config` as second arg
             baseURL = config;
             config = arguments[1] || {};
+            // try to get namespace again from the correct argument
+            Jupyter = config.namespace;
         } else {
             baseURL = Jupyter ? Jupyter.notebook.base_url : '/';
         }


### PR DESCRIPTION
- commit 1: Make sure the Jupyter namespace is set properly when the old API is used and a path is passed
- commit 2: Let the caller configure the model_module where null will skip it entirely (which is what's required when using Thebe)

Fixes #328
