### PR TITLE
Custom serializers at run time

### DIFF
--- a/etc/notebooks/examples/urth-r-widgets.ipynb
+++ b/etc/notebooks/examples/urth-r-widgets.ipynb
@@ -302,6 +302,114 @@
     "</template>\n",
     "\")"
    ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Function returning a custom class. Defining a custom serializer\n",
+    "In this example, we have a function that returns a custom type Foo. We would like to serialize the Foo that's returned so that the value is useful for other widgets."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": [
+    "library(R6)\n",
+    "Foo <- R6Class(\n",
+    "    'Foo',\n",
+    "    public = list(\n",
+    "        foo = function() {\n",
+    "            return (\"The foo is strong with this one!\")\n",
+    "        }\n",
+    "    )\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Now define the custom serializer for Foo by implementing the BaseSerializer methods.\n",
+    "    \n",
+    "For our serialize method, we'll call obj$foo()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "Foo_Serializer <- R6Class(\n",
+    "    'Foo_Serializer',\n",
+    "    inherit = Serializer,\n",
+    "    public = list(\n",
+    "        klass = function() {\n",
+    "            return (\"Foo\")\n",
+    "        },\n",
+    "        serialize = function(obj) {\n",
+    "            return (obj$foo())\n",
+    "        },\n",
+    "        check_packages = function() {\n",
+    "            tryCatch({\n",
+    "                library(base)\n",
+    "            }, error = function(e) {\n",
+    "                return (False)\n",
+    "            })\n",
+    "            return (True)\n",
+    "        },\n",
+    "        initialize = function() {\n",
+    "            #initialize must exists on this class\n",
+    "        }\n",
+    "    )\n",
+    ")\n",
+    "\n",
+    "register_serializer(Foo_Serializer$new())"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": [
+    "aFooFunction <- function() {\n",
+    "    return (Foo$new())\n",
+    "}"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Now when we invoke, the function will return the Foo instance, and we'll see the serialized return value:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "IRdisplay::display_html(\"\n",
+    "    <template is='dom-bind'>\n",
+    "        <urth-core-function id='f3f' ref='aFooFunction' result='{{r}}'></urth-core-function>\n",
+    "        <button onClick='f3f.invoke()'>invoke</button>    \n",
+    "        <span>{{r}}</span>\n",
+    "    </template>\n",
+    "\")"
+   ]
   }
  ],
  "metadata": {

--- a/kernel-r/declarativewidgets/NAMESPACE
+++ b/kernel-r/declarativewidgets/NAMESPACE
@@ -1,4 +1,5 @@
 export(initWidgets)
+export(Serializer)
 import(IRkernel)
 import(uuid)
 import(R6)

--- a/kernel-r/declarativewidgets/R/serializer.r
+++ b/kernel-r/declarativewidgets/R/serializer.r
@@ -7,8 +7,10 @@ Serializer <- R6Class(
         serializer_list = list(),
         serialize = function(obj) {
             #if serializer for the class is registered use it else just return the object
+            ref_klass <- class(obj)
+            klass_name <- if (!is.na(ref_klass[2]) && ref_klass[2] == "R6") ref_klass[1] else ref_klass
             for(klass in names(self$serializer_list)) {
-                if(class(obj) == klass) {
+                if(klass_name == klass) {
                     return (self$serializer_list[[klass]](obj))
                 }
             }

--- a/kernel-r/declarativewidgets/R/serializer.r
+++ b/kernel-r/declarativewidgets/R/serializer.r
@@ -24,6 +24,7 @@ Serializer <- R6Class(
         },
         initialize = function() {
             self$load_serializers()
+            assign("register_serializer", self$register_serializer, envir = .GlobalEnv)
         }
     )
 )

--- a/kernel-r/declarativewidgets/R/widget.r
+++ b/kernel-r/declarativewidgets/R/widget.r
@@ -1,4 +1,4 @@
-#' @include widget_channels.r widget_function.r widget_dataframe.r
+#' @include widget_channels.r widget_function.r widget_dataframe.r serializer.r
 NULL
 
 setClassUnion('CommOrNULL', members = c('Comm', 'NULL'))
@@ -86,12 +86,12 @@ Widget <- R6Class("Widget",
     )
 )
 
-create_widget_instance <- function(class_name, comm) {
+create_widget_instance <- function(class_name, comm, serializer) {
     switch(
         class_name,
-        urth.widgets.widget_function.Function      = return (Widget_Function$new(comm = comm)),
-        urth.widgets.widget_channels.Channels      = return (Widget_Channels$new(comm = comm)),
-        urth.widgets.widget_dataframe.DataFrame    = return (Widget_Dataframe$new(comm = comm)),
+        urth.widgets.widget_function.Function      = return (Widget_Function$new(comm = comm, serializer = serializer)),
+        urth.widgets.widget_channels.Channels      = return (Widget_Channels$new(comm = comm, serializer = serializer)),
+        urth.widgets.widget_dataframe.DataFrame    = return (Widget_Dataframe$new(comm = comm, serializer = serializer)),
         print(c('Got unhandled class_name:', class_name))
     )
 }
@@ -100,11 +100,12 @@ create_widget_instance <- function(class_name, comm) {
 #'
 #' @export
 initWidgets <- function() {
+    serializer <- Serializer$new()
     target_handler <- function(comm, msg_data) {
         #get widget_class
         widget_class <- msg_data$widget_class
         #create the widget instance
-        widget <- create_widget_instance(widget_class, comm)
+        widget <- create_widget_instance(widget_class, comm, serializer)
     }
     library(IRkernel)
     comm_manager <- get("comm_manager", envir = as.environment("package:IRkernel"))()

--- a/kernel-r/declarativewidgets/R/widget_channels.r
+++ b/kernel-r/declarativewidgets/R/widget_channels.r
@@ -80,13 +80,13 @@ Widget_Channels <- R6Class(
                 self$handle_change(msg$data)
             }
         },
-        initialize = function(comm) {
+        initialize = function(comm, serializer) {
             #expose channel to global env
             assign("the_channels", self, envir = .GlobalEnv)
             assign("channel", the_channel, envir = .GlobalEnv)
             #initialize super class Widget
             super$initialize(comm)
-            self$serializer <- Serializer$new()
+            self$serializer <- serializer
         }
     )
 )

--- a/kernel-r/declarativewidgets/R/widget_dataframe.r
+++ b/kernel-r/declarativewidgets/R/widget_dataframe.r
@@ -61,10 +61,10 @@ Widget_Dataframe <- R6Class(
         register_limit = function(limit) {
             self$limit <- limit
         },
-        initialize = function(comm) {
+        initialize = function(comm, serializer) {
             #initialize super class Widget and serializer
             super$initialize(comm)
-            self$serializer <- Serializer$new()
+            self$serializer <- serializer
         }
     )
 )

--- a/kernel-r/declarativewidgets/R/widget_function.r
+++ b/kernel-r/declarativewidgets/R/widget_function.r
@@ -151,9 +151,9 @@ Widget_Function <- R6Class(
             })
             return (names)
         },
-        initialize = function(comm) {
+        initialize = function(comm, serializer) {
             super$initialize(comm)
-            self$serializer <- Serializer$new()
+            self$serializer <- serializer
         }
     )
 )


### PR DESCRIPTION
Resolves #336 
1) Refactored serializers.  Have one serializer for all instances of a widget; rather than before where had an instance of serializer for each widget.
2) Expose the single serializer to the env, so you can `register_serializer(Foo_Serializer$new())`.
3) Support R6 class name extractor of variable in defined env.  Required special treatment vs other objects.
4) Add demo in urth-r-widgets notebook.
