### PR TITLE
Increase timeout on r system tests.

### DIFF
--- a/system-test/urth-r-widgets-specs.js
+++ b/system-test/urth-r-widgets-specs.js
@@ -10,26 +10,26 @@ process.env.PYTHON != "python2" && describe('Widgets R System Test', function() 
 
     it('should print the result of a Function Widget invocation', function(done) {
         boilerplate.browser
-            .waitForElementByClassName('test1', wd.asserters.textInclude('10'), 10000)
+            .waitForElementByClassName('test1', wd.asserters.textInclude('10'), 60000)
             .nodeify(done);
     });
 
     it('should bind and update a channel variable', function(done) {
         boilerplate.browser
             .waitForElementById('invokeButton').click()
-            .waitForElementByClassName('test2', wd.asserters.textInclude('mike'), 10000)
+            .waitForElementByClassName('test2', wd.asserters.textInclude('mike'), 60000)
             .nodeify(done);
     });
 
     it('should print the contents of the Dataframe Widget', function(done) {
         boilerplate.browser
-            .waitForElementByClassName('test3', wd.asserters.textInclude('John'), 10000)
+            .waitForElementByClassName('test3', wd.asserters.textInclude('John'), 60000)
             .nodeify(done);
     });
 
     it('should print the contents of the SparkDataframe Widget', function(done) {
         boilerplate.browser
-            .waitForElementByClassName('test4', wd.asserters.textInclude('John'), 10000)
+            .waitForElementByClassName('test4', wd.asserters.textInclude('John'), 60000)
             .nodeify(done);
     });
 });


### PR DESCRIPTION
This issue will eventually go away with the rework of the system tests boilerplate in the scala system tests branch.  The function will not get invoked in a run all till all the cells run.  The spark r is the last cell and that can sometimes take more time than what is in the timeout.  These run all situations may be appearing elsewhere.  I have replicated the situation locally.  If this issue appears enough you can merge this in else wait for the fix in the scala system test branch.
