### PR TITLE
Fixes #342 - Don't show error when datarows is undefined in urth-viz-table

### DIFF
--- a/elements/urth-viz-table/urth-viz-table.html
+++ b/elements/urth-viz-table/urth-viz-table.html
@@ -160,11 +160,10 @@ The table accepts data via attribute `datarows` and column headers via attribute
                     this.cancelDebouncer(jName);
                 }
                 this.debounce(jName, function () {
+                    this._clearErrorMessages();
                     if (!datarows || !columns) {
-                        this.displayErrorMessage("urth-viz-table: invalid datarows or columns");
                         return;
                     }
-                    this._clearErrorMessages();
                     if (this.hot) {
                         this._updateColumns(columns);
                         this._updateDatarows(datarows);
@@ -361,8 +360,6 @@ The table accepts data via attribute `datarows` and column headers via attribute
                         if (this.datarows) {
                             this._createTable(this.datarows);
                             this._clearErrorMessages();
-                        } else {
-                            this.displayErrorMessage("urth-viz-table: invalid datarows");
                         }
                     }
                 }.bind(this));


### PR DESCRIPTION
fixes #342 
