### PR TITLE
Fix IE and Safari system test

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,9 @@
 env:
   global:
     - DISPLAY=:99.0
-    - BASEURL=http://localhost:9500
-    - BROWSER_LIST="chrome firefox"
+    - PORT_MAP="-p 4000:8888"
+    - BASEURL=http://declarativewidgets.org:4000
+    - BROWSER_LIST="chrome firefox safari InternetExplorer"
 
 sudo: required
 
@@ -18,6 +19,8 @@ addons:
   firefox: "latest"
   sauce_connect:
     no_ssl_bump_domains: all
+  hosts:
+    - declarativewidgets.org
 
 before_script:
   - curl -sL https://deb.nodesource.com/setup_4.x | sudo -E bash -

--- a/etc/notebooks/tests/urth-core-bind.ipynb
+++ b/etc/notebooks/tests/urth-core-bind.ipynb
@@ -22,7 +22,7 @@
     "        is='urth-core-import' package='PolymerElements/paper-input'>\n",
     "<template id='bindtemplate' is='urth-core-bind'>    \n",
     "    <span id='titleSpan'>[[title]]</span>\n",
-    "    <paper-input id='titleInput' label='Title' value='{{title}}'></paper-input>\n",
+    "    <input id='titleInput' type='text' value='{{title::input}}'/>\n",
     "</template>"
    ]
   },
@@ -102,7 +102,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.4.4"
+   "version": "3.5.1"
   }
  },
  "nbformat": 4,

--- a/etc/notebooks/tests/urth-r-widgets.ipynb
+++ b/etc/notebooks/tests/urth-r-widgets.ipynb
@@ -143,7 +143,7 @@
     "IRdisplay::display_html(\"\n",
     "<template is='urth-core-bind'>\n",
     "    <urth-core-function id='f' ref='set_user'></urth-core-function>\n",
-    "    <button onClick='f.invoke()'>invoke</button><br/>\n",
+    "    <button id='invokeButton' onClick='f.invoke()'>invoke</button><br/>\n",
     "</template>\n",
     "\")"
    ]

--- a/system-test/urth-core-bind-specs.js
+++ b/system-test/urth-core-bind-specs.js
@@ -18,7 +18,7 @@ describe('Urth Core Bind', function() {
             .waitForElementById('titleInput', wd.asserters.isDisplayed, 10000)
             .elementById('titleInput')
             .click()
-            .keys(inputString)
+            .type(inputString)
             .elementById('titleSpan')
             .text().should.eventually.include(inputString)
             .nodeify(done);
@@ -32,6 +32,8 @@ describe('Urth Core Bind', function() {
         boilerplate.browser
             .waitForElementById('t2Person', wd.asserters.isDisplayed, 10000)
             .elementById('t2Person')
+            .click()
+            .type(boilerplate.SPECIAL_KEYS.Enter) // Needed for IE
             .type(inputString)
             .elementById('t3Person')
             .text().should.eventually.include(inputString)

--- a/system-test/urth-r-widgets-specs.js
+++ b/system-test/urth-r-widgets-specs.js
@@ -16,7 +16,7 @@ process.env.PYTHON != "python2" && describe('Widgets R System Test', function() 
 
     it('should bind and update a channel variable', function(done) {
         boilerplate.browser
-            .elementByXPath('//button[text()="invoke"]').click()
+            .waitForElementById('invokeButton').click()
             .waitForElementByClassName('test2', wd.asserters.textInclude('mike'), 10000)
             .nodeify(done);
     });

--- a/system-test/urth-system-test-specs.js
+++ b/system-test/urth-system-test-specs.js
@@ -30,6 +30,8 @@ describe('Widgets System Test', function() {
         boilerplate.browser
             .elementsByCssSelector('div.output_area').nth(4)
             .elementByCssSelector('>', 'input')
+            .click()
+            .type(boilerplate.SPECIAL_KEYS.Enter) // Needed for IE
             .type('B')
             .waitForElementById('test3', wd.asserters.textInclude('B'), 10000)
             .nodeify(done);
@@ -39,6 +41,8 @@ describe('Widgets System Test', function() {
         boilerplate.browser
             .elementsByCssSelector('div.output_area').nth(3)
             .elementByCssSelector('>', 'input')
+            .click()
+            .type(boilerplate.SPECIAL_KEYS.Enter) // Needed for IE
             .type('2')
             .elementByCssSelector('#test2')
             .text().should.eventually.include('A2')
@@ -51,6 +55,8 @@ describe('Widgets System Test', function() {
         boilerplate.browser
             .elementsByCssSelector('div.output_area').nth(5)
             .elementByCssSelector('>', 'input')
+            .click()
+            .type(boilerplate.SPECIAL_KEYS.Enter) // Needed for IE
             .type('watched message')
             .waitForElementById('test4', wd.asserters.textInclude('watched message'), 10000)
             .nodeify(done);

--- a/system-test/utils/boilerplate.js
+++ b/system-test/utils/boilerplate.js
@@ -28,8 +28,13 @@ wd.configureHttp({
 
 //  The browser capabilities we would like setup by selenium
 var desired = {browserName: 'chrome', platform: 'OS X 10.10'};
-desired.platform = args.platform || desired.platform;
+if (args.browser && args.browser === 'InternetExplorer') {
+    args.browser = 'internet explorer';
+}
 desired.browserName = args.browser || desired.browserName;
+desired.platform = args.platform ||
+    (desired.browserName === 'internet explorer' || desired.browserName === 'MicrosoftEdge') ?
+        'Windows 10': desired.platform;
 desired.tags = ['widgets', 'system-test', desired.browserName];
 // If there is a build number, include it in the desired attributes for sauce labs
 if (process.env.TRAVIS_JOB_NUMBER) {
@@ -55,6 +60,7 @@ console.log('Sauce access key is defined? ', !!process.env.SAUCE_ACCESS_KEY);
 var Boilerplate = function(){
   this.browser = wd.promiseChainRemote(testServer);
   this.allPassed = true;
+  this.SPECIAL_KEYS = wd.SPECIAL_KEYS;
 };
 
 /**


### PR DESCRIPTION
Changes to fix and enable IE and Safari system tests.
1. Changed port to `4000` as `9500` is not a port that is proxied by Safari: [Safari proxied ports](https://wiki.saucelabs.com/display/DOCS/Sauce+Connect+FAQS#SauceConnectFAQS-CanIAccessApplicationsonlocalhost?)
2. Use `declarativewidgets.org` instead of `localhost` for url to get around Safari web socket sauce connect issues: [WebSockets with Sauce Connect and Safari](https://support.saucelabs.com/customer/en/portal/articles/2146230-using-websockets-with-sauce-connect-and-safari)
3. Limited full browser list and full system test suite runs to the mainline build (Python 3/Jupyter 4) for now and only execute subset of tests on one browser for Python 2 and Jupyter 4.2.
4. Changed `urth-core-bind` test to use `input` instead of `paper-input` as Safari has text input issues on `paper-input`.
5. Some elements need additional focus through `Enter` key on IE to get around [a bug in the notebook](https://github.com/jupyter/notebook/issues/1395#issuecomment-215140691)
6. Use `type` instead of `keys` api since Safari doesn't support the `keys` api on some elements.
7. Modified the boilerplate test code to handle internet explorer and select appropriate platform.
8. Refactored the `all` and `system-test` Makefile targets to only start selenium standalone server once for all system-test runs in hopes of avoiding the `ECONNREFUSED` error being seen on pull request travis builds.
