### PR TITLE
Added logging behavior to silence widget logging

### DIFF
--- a/elements/urth-core-behaviors/error-display-behavior.html
+++ b/elements/urth-core-behaviors/error-display-behavior.html
@@ -7,6 +7,7 @@
 This behavior is used to encapsulate some of the services needed for urth elements.
 -->
 <link rel="import" href="shared-styles.html">
+
 <style is="custom-style" include="shared-styles"></style>
 <script>
     'use strict';

--- a/elements/urth-core-behaviors/execution-complete-behavior.html
+++ b/elements/urth-core-behaviors/execution-complete-behavior.html
@@ -6,16 +6,18 @@
 <!--
 This Behavior represents the completion of a code cell's execution.
 -->
+<link rel='import' href='logging-behavior.html'>
+
 <script>
   (function() {
     'use strict';
     var Urth = window.Urth = window.Urth || {};
 
-    Urth.ExecutionCompleteBehavior = {
+    Urth.ExecutionCompleteBehavior = [{
 
       ready: function() {
         // Code execution defined to be complete when an ExecuteReply is received.
-        console.debug("Registering _onExecutionComplete for Execute Reply messages.");
+        this._debug("Registering _onExecutionComplete for Execute Reply messages.");
         this.__replyCallback = this._onExecutionComplete.bind(this);
 
         Urth.events.on(
@@ -24,7 +26,7 @@ This Behavior represents the completion of a code cell's execution.
       },
 
       detached: function() {
-          console.debug("Unregistering _onExecutionComplete for Execute Reply messages.");
+          this._debug("Unregistering _onExecutionComplete for Execute Reply messages.");
           if (this.__replyCallback){
               Urth.events.off(
                   'shell_reply.Kernel', this.__replyCallback
@@ -36,6 +38,6 @@ This Behavior represents the completion of a code cell's execution.
        * A callback fired when code execution has completed for a cell.
        */
       _onExecutionComplete: function() {}
-    };
+    }, Urth.LoggingBehavior];
   })();
 </script>

--- a/elements/urth-core-behaviors/jupyter-kernel-observer.html
+++ b/elements/urth-core-behaviors/jupyter-kernel-observer.html
@@ -6,6 +6,8 @@
 <!--
 This behavior is used to implement handlers to kernel events
 -->
+<link rel='import' href='logging-behavior.html'>
+
 <script>
     (function() {
         'use strict';
@@ -17,13 +19,13 @@ This behavior is used to implement handlers to kernel events
          * @group Urth Core
          * @polymerBehavior Urth.JupyterKernelObserver
          */
-        Urth.JupyterKernelObserver = {
+        Urth.JupyterKernelObserver = [{
 
             created: function(){
                 if (!Urth.events) {
                     return;
                 }
-                console.debug("Registering onKernelReady for Kernel Ready messages.")
+                this._debug("Registering onKernelReady for Kernel Ready messages.")
 
                 this.__kernelReadyCallback = function(){
                     this.onKernelReady(Urth.kernel);
@@ -39,7 +41,7 @@ This behavior is used to implement handlers to kernel events
 
             detached: function(){
                 if (this.__kernelReadyCallback) {
-                    console.debug("Unregistering onKernelReady for Kernel Ready messages.")
+                    this._debug("Unregistering onKernelReady for Kernel Ready messages.")
                     Urth.events.off(
                         'kernel_ready.Kernel', this.__kernelReadyCallback
                     );
@@ -57,6 +59,6 @@ This behavior is used to implement handlers to kernel events
             onKernelReady: function(kernel){}
 
 
-        };
+        }, Urth.LoggingBehavior];
     })();
 </script>

--- a/elements/urth-core-behaviors/jupyter-widget-behavior.html
+++ b/elements/urth-core-behaviors/jupyter-widget-behavior.html
@@ -7,6 +7,8 @@
 This behavior is used to encapsulate some of the services needed for ipywidgets.
 -->
 <link rel='import' href='error-display-behavior.html'>
+<link rel='import' href='logging-behavior.html'>
+
 <script>
     (function() {
         'use strict';
@@ -44,7 +46,7 @@ This behavior is used to encapsulate some of the services needed for ipywidgets.
             },
 
             _doCreateModel: function(){
-                console.debug('Urth.JupyterWidgetBehavior createModel', this.kernelClass);
+                this._debug('Urth.JupyterWidgetBehavior createModel', this.kernelClass);
                 Urth.kernel.widget_manager.new_widget(
                     {
                         model_module: 'jupyter-decl-widgets/DeclWidgetModel',
@@ -59,7 +61,7 @@ This behavior is used to encapsulate some of the services needed for ipywidgets.
                             return;
                         }
 
-                        console.log('Model creation successful!', model);
+                        this._log('Model creation successful!', model);
                         this.__modelChangeCallback = this._onModelChange.bind(this);
                         this.__commCloseCallback = this._handleCommDisconnect.bind(this);
 
@@ -71,7 +73,7 @@ This behavior is used to encapsulate some of the services needed for ipywidgets.
                         this.fire('connected');
                     }.bind(this),
                     function(error){
-                        console.error(error);
+                        this._error(error);
                     }
                 );
             },
@@ -89,9 +91,9 @@ This behavior is used to encapsulate some of the services needed for ipywidgets.
             },
 
             _retryCreateModel: function(){
-                console.debug('Urth.JupyterWidgetBehavior _retryCreateModel - Waiting for another code exec...');
+                this._debug('Urth.JupyterWidgetBehavior _retryCreateModel - Waiting for another code exec...');
                 this.__shellReplyCallback = function(){
-                    console.debug('Urth.JupyterWidgetBehavior createModel - retrying...');
+                    this._debug('Urth.JupyterWidgetBehavior createModel - retrying...');
                     this._doCreateModel();
                 }.bind(this);
 
@@ -101,7 +103,7 @@ This behavior is used to encapsulate some of the services needed for ipywidgets.
             },
 
             _handleCommDisconnect: function(){
-                console.debug('Urth.JupyterWidgetBehavior _handleCommDisconnect - Model comm got closed');
+                this._debug('Urth.JupyterWidgetBehavior _handleCommDisconnect - Model comm got closed');
                 if( this.retryCount > 0 ){
                     try{
                         this._retryCreateModel();
@@ -110,7 +112,7 @@ This behavior is used to encapsulate some of the services needed for ipywidgets.
                         this.retryCount--;
                     }
                 } else {
-                    console.error('Urth.JupyterWidgetBehavior no longer retrying createModel!');
+                    this._error('Urth.JupyterWidgetBehavior no longer retrying createModel!');
                 }
             },
 
@@ -143,11 +145,11 @@ This behavior is used to encapsulate some of the services needed for ipywidgets.
              */
             send: function( msg ){
                 if(this.isConnected()){
-                    console.debug('Urth.JupyterWidgetBehavior send - sending message', msg);
+                    this._debug('Urth.JupyterWidgetBehavior send - sending message', msg);
                     this.model.send(msg, this._callbacks());
                 }
                 else{
-                    console.warn('Urth.JupyterWidgetBehavior send - model not ready, cannot send message');
+                    this._warn('Urth.JupyterWidgetBehavior send - model not ready, cannot send message');
                 }
             },
 
@@ -160,7 +162,7 @@ This behavior is used to encapsulate some of the services needed for ipywidgets.
              */
             sync: function( values ){
                 if(this.isConnected()) {
-                    console.debug('Urth.JupyterWidgetBehavior sync - sending values', values);
+                    this._debug('Urth.JupyterWidgetBehavior sync - sending values', values);
                     var valKeys = Object.keys(values || {});
                     valKeys.forEach(function (value) {
                         this.model.set(value, values[value], {silent: true});
@@ -170,7 +172,7 @@ This behavior is used to encapsulate some of the services needed for ipywidgets.
                         this.model.save_changes();
                 }
                 else{
-                    console.warn('Urth.JupyterWidgetBehavior sync - model not ready, cannot sync');
+                    this._warn('Urth.JupyterWidgetBehavior sync - model not ready, cannot sync');
                 }
             },
 
@@ -225,7 +227,7 @@ This behavior is used to encapsulate some of the services needed for ipywidgets.
             onModelReady: function(){},
 
             _onModelChange: function(options){
-                console.debug('Urth.JupyterWidgetBehavior _onModelChange', options);
+                this._debug('Urth.JupyterWidgetBehavior _onModelChange', options);
                 var changes = options.changed;
                 Object.keys(changes).forEach(function(change){
                     var funcName = "onModel"+(change[0].toUpperCase()+change.substring(1))+"Change";
@@ -275,6 +277,6 @@ This behavior is used to encapsulate some of the services needed for ipywidgets.
         };
 
         // JupyterWidgetBehavior inherits DisplayErrorBehavior
-        Urth.JupyterWidgetBehavior = [Urth.DisplayErrorBehavior, Urth.JupyterWidgetBehaviorImpl];
+        Urth.JupyterWidgetBehavior = [Urth.DisplayErrorBehavior, Urth.JupyterWidgetBehaviorImpl, Urth.LoggingBehavior];
     })();
 </script>

--- a/elements/urth-core-behaviors/logging-behavior.html
+++ b/elements/urth-core-behaviors/logging-behavior.html
@@ -1,0 +1,137 @@
+<!--
+# Copyright (c) Jupyter Development Team.
+# Distributed under the terms of the Modified BSD License.
+-->
+<script>
+    'use strict';
+    (function() {
+        var Urth = window.Urth = window.Urth || {};
+
+        /**
+         * Behavior for logging. It redefines the logging methods in Polymer.Base to
+         * control their invocation based on the log levels set in the `log` property.
+         * Setting the `log` property to a comma separated list of levels turns on that particular
+         * level. By default, no logs are sent to the console. A global override to turn on all logs
+         * is available by setting `Urth.debug` to `true`.
+         *
+         * @group Urth Core
+         * @polymerBehavior Urth.LoggingBehavior
+         */
+        Urth.LoggingBehavior = {
+
+            properties: {
+
+                /**
+                 * Comma separated string of log levels to allow. The levels are INFO, WARN, DEBUG, ERROR, ALL.
+                 * An empty string or unset property is interpreted no logs
+                 */
+                log: {
+                    type: String,
+                    value: "",
+                    reflectToAttribute: true
+                },
+
+                /**
+                 * Internal map representation to facilitate test
+                 */
+                _logBooleanMap: {
+                    type: Object,
+                    computed: '_toLogBooleanMap(log)'
+                }
+            },
+
+            /**
+             * Converts the comma separated string into a map of booleans
+             * @param log
+             * @return {{}}
+             * @private
+             */
+            _toLogBooleanMap: function(log){
+
+                var _logBooleanMap = {};
+                (log || "").split(',')
+                    .map(function(part){return part.trim().toUpperCase();})
+                    .filter(function(part){
+                        return !!part;
+                    })
+                    .forEach(function(level){
+                        _logBooleanMap[level] = true;
+                    });
+
+                return _logBooleanMap;
+
+            },
+
+            /**
+             * Alias method for info level messages
+             * @private
+             */
+            _log: function(){
+              this._info.apply(this, arguments);
+            },
+
+            /**
+             * Logs info level messages
+             * @private
+             */
+            _info: function() {
+                if( this._testLevel("INFO") ){
+                    Polymer.Base._log.call(this, arguments);
+                }
+            },
+
+            /**
+             * Logs warn level messages
+             * @private
+             */
+            _warn: function() {
+                if( this._testLevel("WARN") ){
+                    Polymer.Base._warn.call(this, arguments);
+                }
+            },
+
+            /**
+             * Logs debug level messages
+             * @private
+             */
+            _debug: function() {
+                if( this._testLevel("DEBUG") ){
+
+                    var consoleDebug = console["debug"] || console["log"];
+                    if(console["debug"]){
+                        consoleDebug.apply(console, arguments)
+                    }
+
+                }
+            },
+
+            /**
+             * Logs error level messages
+             * @private
+             */
+            _error: function() {
+                if( this._testLevel("ERROR") ){
+                    Polymer.Base._error.call(this, arguments);
+                }
+            },
+
+            /**
+             * Internal utility to determine if the message should be sent to the console
+             * @param level
+             * @return {boolean} True if message should reach thec onsole
+             * @private
+             */
+            _testLevel: function( level ){
+                var _logBooleanMap;
+                try{
+                    _logBooleanMap = this._logBooleanMap;
+                }catch(e){
+                    _logBooleanMap = this._toLogBooleanMap(this.getAttribute("log"));
+                }
+
+                return !!(_logBooleanMap[level] || _logBooleanMap.ALL || (Urth && Urth.debug));
+            }
+
+        };
+    })();
+</script>

--- a/elements/urth-core-behaviors/test/jupyter-widget-behavior.html
+++ b/elements/urth-core-behaviors/test/jupyter-widget-behavior.html
@@ -36,7 +36,24 @@
 
     <!-- STEP 3: Setup document with DOM to test. Use test-fixture elements
          to ease setup and cleanup of elements. -->
-    <!-- no need for fixtures -->
+    <test-fixture id='basic'>
+        <template>
+            <test-jup-widget></test-jup-widget>
+        </template>
+    </test-fixture>
+
+    <!-- This is a custom element that will be used to test
+         save invocation. -->
+    <dom-module id="test-jup-widget">
+        <script>
+            HTMLImports.whenReady(function () {
+                Polymer({
+                    is: 'test-jup-widget',
+                    behaviors: [ Urth.JupyterWidgetBehavior]
+                });
+            });
+        </script>
+    </dom-module>
 
     <script>
         // STEP 4: Define any globals needed by the test suite.
@@ -50,9 +67,9 @@
                     }
                 };
 
-                var testObject = Polymer.Base.mixin({
-                    onModelResultChange: function(){}
-                }, Urth.JupyterWidgetBehaviorImpl);
+                var testObject = fixture('basic');
+
+                testObject.onModelResultChange = function(){}
 
                 var onModelResultChange = sinon.spy(testObject, "onModelResultChange")
 
@@ -70,9 +87,9 @@
                     status: "error"
                 };
 
-                var testObject = Polymer.Base.mixin({
-                    displayErrorMessage:function(){}
-                }, Urth.JupyterWidgetBehaviorImpl);
+                var testObject = fixture('basic');
+
+                testObject.displayErrorMessage = function(){};
 
                 var displayFunc = sinon.stub(testObject, "displayErrorMessage");
 
@@ -86,12 +103,12 @@
         describe('sync', function() {
             it('should call set on the model on each property and save changes', function() {
 
-                var testObject = Polymer.Base.mixin({
-                    model: {
-                        set:function(){},
-                        save_changes: function(){}
-                    }
-                }, Urth.JupyterWidgetBehaviorImpl);
+                var testObject = fixture('basic');
+                testObject.model =  {
+                    set:function(){},
+                    save_changes: function(){},
+                    off: function(){}
+                };
 
                 var setFunc = sinon.spy(testObject.model, "set");
                 var save_changes = sinon.spy(testObject.model, "save_changes");
@@ -115,12 +132,12 @@
 
             it('should not call set nor save_changes on model if values is {}', function() {
 
-                var testObject = Polymer.Base.mixin({
-                    model: {
-                        set:function(){},
-                        save_changes: function(){}
-                    }
-                }, Urth.JupyterWidgetBehaviorImpl);
+                var testObject = fixture('basic');
+                testObject.model =  {
+                    set:function(){},
+                    save_changes: function(){},
+                    off: function(){}
+                };
 
                 var setFunc = sinon.spy(testObject.model, "set");
                 var save_changes = sinon.spy(testObject.model, "save_changes");
@@ -134,12 +151,12 @@
 
             it('should not call set nor save_changes on model if values is undefined', function() {
 
-                var testObject = Polymer.Base.mixin({
-                    model: {
-                        set:function(){},
-                        save_changes: function(){}
-                    }
-                }, Urth.JupyterWidgetBehaviorImpl);
+                var testObject = fixture('basic');
+                testObject.model =  {
+                    set:function(){},
+                    save_changes: function(){},
+                    off: function(){}
+                };
 
                 var setFunc = sinon.spy(testObject.model, "set");
                 var save_changes = sinon.spy(testObject.model, "save_changes");
@@ -155,22 +172,21 @@
         describe('_callback', function() {
             it('should return the minimum set of iopub callbacks if element does not have parent cell', function() {
 
-                var testObject = Polymer.Base.mixin(Urth.JupyterWidgetBehaviorImpl, {
-                    parentCell: function(){
-                        //mocked to return undefined
-                        return undefined;
-                    },
-                    model: {
-                        callbacks: function(){
-                           return {
-                               iopub: {
-                                   status: "the status handler"
-                               }
-                           }
+                var testObject = fixture('basic');
+                testObject.parentCell = function(){
+                    //mocked to return undefined
+                    return undefined;
+                };
+                testObject.model = {
+                    callbacks: function(){
+                        return {
+                            iopub: {
+                                status: "the status handler"
+                            }
                         }
                     },
-                    mixin: Polymer.Base.mixin
-                });
+                    off: function(){}
+                };
 
                 expect(testObject._callbacks()).to.eql( {
                     iopub: {
@@ -181,33 +197,32 @@
 
             it('should return the a combination of parent cell callbacks and model callbacks if element has a parent cell', function() {
 
-                var testObject = Polymer.Base.mixin(Urth.JupyterWidgetBehaviorImpl, {
-                    parentCell: function(){
-                        //mocked to return undefined
-                        return {
-                            get_callbacks: function(){
-                                return {
-                                    shell: {
-                                        reply: "the reply handler"
-                                    },
-                                    iopub: {
-                                        output: "the output handler"
-                                    }
-                                }
-                            }
-                        };
-                    },
-                    model: {
-                        callbacks: function(){
+                var testObject = fixture('basic');
+                testObject.parentCell = function(){
+                    //mocked to return undefined
+                    return {
+                        get_callbacks: function(){
                             return {
+                                shell: {
+                                    reply: "the reply handler"
+                                },
                                 iopub: {
-                                    status: "the status handler"
+                                    output: "the output handler"
                                 }
                             }
                         }
+                    };
+                };
+                testObject.model = {
+                    callbacks: function(){
+                        return {
+                            iopub: {
+                                status: "the status handler"
+                            }
+                        }
                     },
-                    mixin: Polymer.Base.mixin
-                });
+                    off: function(){}
+                };
 
                 expect(testObject._callbacks()).to.eql( {
                     shell: {

--- a/elements/urth-core-behaviors/test/logging-behavior.html
+++ b/elements/urth-core-behaviors/test/logging-behavior.html
@@ -1,0 +1,164 @@
+<!doctype html>
+<!--
+# Copyright (c) Jupyter Development Team.
+# Distributed under the terms of the Modified BSD License.
+-->
+<html>
+<head>
+    <meta charset="utf-8">
+    <!-- STEP 1: Provide a title for the test suite. -->
+    <title>urth-core-function tests</title>
+    <meta name='viewport' content='width=device-width, minimum-scale=1.0, initial-scale=1.0, user-scalable=yes'>
+
+    <!-- Need the web component polyfill for browsers without native support. -->
+    <script src='../../webcomponentsjs/webcomponents-lite.js'></script>
+
+    <!-- Load test framework and helpers. -->
+    <script src='../../web-component-tester/browser.js'></script>
+    <script src='../../test-fixture/test-fixture-mocha.js'></script>
+    <link rel='import' href='../../polymer/polymer.html'>
+    <link rel='import' href='../../test-fixture/test-fixture.html'>
+
+    <!-- STEP 2: Import the element to test. -->
+    <link rel='import' href='../logging-behavior.html'>
+
+</head>
+
+<body>
+
+    <!-- STEP 3: Setup document with DOM to test. Use test-fixture elements
+         to ease setup and cleanup of elements. -->
+    <test-fixture id='basic'>
+        <template>
+            <test-logging></test-logging>
+        </template>
+    </test-fixture>
+
+    <test-fixture id='info-only'>
+        <template>
+            <test-logging log="info"></test-logging>
+        </template>
+    </test-fixture>
+
+    <test-fixture id='info-error-only'>
+        <template>
+            <test-logging log="info,error"></test-logging>
+        </template>
+    </test-fixture>
+
+    <test-fixture id='all'>
+        <template>
+            <test-logging log="all"></test-logging>
+        </template>
+    </test-fixture>
+
+    <!-- This is a custom element that will be used to test
+         save invocation. -->
+    <dom-module id="test-logging">
+        <script>
+            HTMLImports.whenReady(function () {
+                Polymer({
+                    is: 'test-logging',
+                    behaviors: [ Urth.LoggingBehavior]
+                });
+            });
+        </script>
+    </dom-module>
+
+    <script>
+        // STEP 4: Define any globals needed by the test suite.
+        beforeEach(function(){
+            if( Urth )
+                delete Urth.debug;
+        })
+
+
+        // STEP 5: Define suite(s) and tests.
+        describe('_toLogBooleanMap', function() {
+            it('should create boolean map with provided comma separated string', function() {
+                var actual = Urth.LoggingBehavior._toLogBooleanMap('info, DEBUG, eRROR,   warn');
+                expect(actual).to.be.deep.eql({
+                    "INFO": true,
+                    "DEBUG": true,
+                    "ERROR": true,
+                    "WARN": true
+                });
+            });
+
+            it('should empty map with empty string', function() {
+                var actual = Urth.LoggingBehavior._toLogBooleanMap('');
+                expect(actual).to.be.deep.eql({});
+            });
+
+            it('should empty map with undefined passed in', function() {
+                var actual = Urth.LoggingBehavior._toLogBooleanMap();
+                expect(actual).to.be.deep.eql({});
+            });
+
+            it('should empty map with provided comman separated string that has spaces only', function() {
+                var actual = Urth.LoggingBehavior._toLogBooleanMap('  ,   ,  ,,,   ,');
+                expect(actual).to.be.deep.eql({});
+            });
+
+            it('should create boolean map with provided comma separated string that includes spaces only', function() {
+                var actual = Urth.LoggingBehavior._toLogBooleanMap('info, DEBUG, ,eRROR,   warn, ');
+                expect(actual).to.be.deep.eql({
+                    "INFO": true,
+                            "DEBUG": true,
+                            "ERROR": true,
+                            "WARN": true
+                });
+            });
+        });
+
+        describe('_testLevel', function() {
+            it('should not allow any logging', function () {
+                var testLogging = fixture('basic');
+                expect(testLogging._testLevel('INFO')).to.be.false;
+                expect(testLogging._testLevel('WARN')).to.be.false;
+                expect(testLogging._testLevel('DEBUG')).to.be.false;
+                expect(testLogging._testLevel('ERROR')).to.be.false;
+            });
+
+            it('should allow all logging with global override', function () {
+                Urth.debug = true;
+                var testLogging = fixture('basic');
+                expect(testLogging._testLevel('INFO')).to.be.true;
+                expect(testLogging._testLevel('WARN')).to.be.true;
+                expect(testLogging._testLevel('DEBUG')).to.be.true;
+                expect(testLogging._testLevel('ERROR')).to.be.true;
+            });
+
+            it('should allow all when log is set to all', function () {
+                Urth.debug = true;
+                var testLogging = fixture('all');
+                expect(testLogging._testLevel('INFO')).to.be.true;
+                expect(testLogging._testLevel('WARN')).to.be.true;
+                expect(testLogging._testLevel('DEBUG')).to.be.true;
+                expect(testLogging._testLevel('ERROR')).to.be.true;
+            });
+
+            it('should allow only allow info log is set to info', function () {
+                var testLogging = fixture('info-only');
+                expect(testLogging._testLevel('INFO')).to.be.true;
+                expect(testLogging._testLevel('WARN')).to.be.false;
+                expect(testLogging._testLevel('DEBUG')).to.be.false;
+                expect(testLogging._testLevel('ERROR')).to.be.false;
+            });
+
+            it('should allow only allow info and error log is set to info,error', function () {
+                var testLogging = fixture('info-error-only');
+                expect(testLogging._testLevel('INFO')).to.be.true;
+                expect(testLogging._testLevel('WARN')).to.be.false;
+                expect(testLogging._testLevel('DEBUG')).to.be.false;
+                expect(testLogging._testLevel('ERROR')).to.be.true;
+            });
+
+            it('should allow return false when it gets unsupported levels', function () {
+                var testLogging = fixture('basic');
+                expect(testLogging._testLevel('UNSUPPORTED')).to.be.false;
+            });
+        });
+    </script>
+</body>
+</html>

--- a/elements/urth-core-bind/urth-core-bind.html
+++ b/elements/urth-core-bind/urth-core-bind.html
@@ -5,6 +5,7 @@
 <link rel="import" href="../polymer/polymer.html">
 <link rel="import" href="../promise-polyfill/promise-polyfill.html">
 <link rel="import" href="./dom-bind-behavior.html">
+<link rel="import" href="../urth-core-behaviors/logging-behavior.html">
 <link rel="import" href="../urth-core-channel/urth-core-channel.html">
 <link rel="import" href="../urth-core-import/urth-core-import-broker.html">
 
@@ -84,7 +85,10 @@
                     observer: '_onChannelChange'
                 }
             },
-            behaviors: [Urth.DomBindBehavior],
+            behaviors: [
+                Urth.DomBindBehavior,
+                Urth.LoggingBehavior
+            ],
 
             created: function() {
                 this._createChannel();

--- a/elements/urth-core-channel/test/urth-core-channel-broker.html
+++ b/elements/urth-core-channel/test/urth-core-channel-broker.html
@@ -42,7 +42,7 @@
              * must be mocked there.
              */
             sinon.stub(Urth['urth-core-channel-broker'].prototype, 'createModel');
-            sinon.stub(Urth.JupyterKernelObserver, 'created');
+            sinon.stub(Urth.JupyterKernelObserver[0], 'created');
             sinon.stub(Urth.JupyterWidgetBehaviorImpl, 'detached');
             sinon.stub(Urth['urth-core-channel-broker'].prototype, '_callbacks');
         });

--- a/elements/urth-core-channel/test/urth-core-channel.html
+++ b/elements/urth-core-channel/test/urth-core-channel.html
@@ -83,7 +83,7 @@
              * must be mocked there.
              */
             sinon.stub(Urth['urth-core-channel-broker'].prototype, 'createModel');
-            sinon.stub(Urth.JupyterKernelObserver, 'created');
+            sinon.stub(Urth.JupyterKernelObserver[0], 'created');
             sinon.stub(Urth.JupyterWidgetBehaviorImpl, 'detached');
             sinon.stub(Urth['urth-core-channel-broker'].prototype, '_callbacks');
         });

--- a/elements/urth-core-channel/urth-core-channel-broker.html
+++ b/elements/urth-core-channel/urth-core-channel-broker.html
@@ -135,7 +135,7 @@ var broker = window.Urth['urth-core-channel-broker'].getChannelBroker();
              * @method onKernelReady
              */
             onKernelReady: function() {
-                console.debug('urth-core-channel-broker onKernelReady, creating model...');
+                this._debug('urth-core-channel-broker onKernelReady, creating model...');
                 this.createModel('urth.widgets.widget_channels.Channels', 10);
             },
 
@@ -147,13 +147,13 @@ var broker = window.Urth['urth-core-channel-broker'].getChannelBroker();
              * @param {Object} options
              */
             onModelChange: function(options) {
-                console.debug('urth-core-channel-broker onModelChange', options);
+                this._debug('urth-core-channel-broker onModelChange', options);
 
                 var changes = options.changed;
                 Object.keys(changes).filter(function(change){
                     return this._validPath(change);
                 }.bind(this)).forEach(function(change){
-                    console.debug('urth-core-channel-broker onModelChange changed ', change, changes[change]);
+                    this._debug('urth-core-channel-broker onModelChange changed ', change, changes[change]);
                     /**
                      * Handle an item change represented by the given path and value.
                      * The path is of the form <CHANNEL_NAME>:<ITEM_NAME>, e.g. "c:user".
@@ -164,7 +164,7 @@ var broker = window.Urth['urth-core-channel-broker'].getChannelBroker();
             },
 
             onModelReady: function() {
-                console.debug('urth-core-channel-broker onModelReady');
+                this._debug('urth-core-channel-broker onModelReady');
             },
 
             /**
@@ -330,7 +330,7 @@ var broker = window.Urth['urth-core-channel-broker'].getChannelBroker();
                     _globalChannels[channelName] = initChannel(channelName);
                     Polymer.Base.set(channelName, {}, this);
                     this.reload(channelName);
-                    console.debug('urth-core-channel-broker _createGlobalChannel: ' +
+                    this._debug('urth-core-channel-broker _createGlobalChannel: ' +
                         'created new channel', channelName, '.'
                     );
                 }
@@ -343,7 +343,7 @@ var broker = window.Urth['urth-core-channel-broker'].getChannelBroker();
                 if (_globalChannels[channelName]) {
                     return _globalChannels[channelName];
                 } else {
-                    console.warn('urth-core-channel-broker _getGlobalChannel: ' +
+                    this._warn('urth-core-channel-broker _getGlobalChannel: ' +
                         'channel', channelName, 'does not exist'
                     );
                 }

--- a/elements/urth-core-channel/urth-core-channel.html
+++ b/elements/urth-core-channel/urth-core-channel.html
@@ -5,7 +5,7 @@
 <link rel="import" href="../polymer/polymer.html">
 <link rel="import" href="./urth-core-channel-broker.html">
 <link rel="import" href="./urth-core-channel-viewer.html">
-
+<link rel="import" href="../urth-core-behaviors/logging-behavior.html">
 
 <!--
 An element that provides [monostate](http://c2.com/cgi/wiki?MonostatePattern)
@@ -111,6 +111,8 @@ dataChannel.set('user', 'Luke');
                     value: false
                 }
             },
+
+            behaviors: [Urth.LoggingBehavior],
 
             /**
              * Clears all the data in the channel.
@@ -221,7 +223,7 @@ dataChannel.set('user', 'Luke');
                     Object.keys(data).forEach(function(key) {
                         element[key] = data[key];
                     });
-                    console.debug('urth-core-channel registered element to channel',
+                    this._debug('urth-core-channel registered element to channel',
                             this.name);
                 }
             },

--- a/elements/urth-core-dataframe/test/urth-core-dataframe.html
+++ b/elements/urth-core-dataframe/test/urth-core-dataframe.html
@@ -43,8 +43,8 @@
              */
             sinon.stub(Urth["urth-core-dataframe"].prototype, "createModel");
             sinon.stub(Urth["urth-core-dataframe"].prototype, "displayErrorMessage");
-            sinon.stub(Urth.ExecutionCompleteBehavior, "ready");
-            sinon.stub(Urth.ExecutionCompleteBehavior, "detached");
+            sinon.stub(Urth.ExecutionCompleteBehavior[0], "ready");
+            sinon.stub(Urth.ExecutionCompleteBehavior[0], "detached");
         });
 
         // STEP 5: Define suite(s) and tests.

--- a/elements/urth-core-dataframe/urth-core-dataframe.html
+++ b/elements/urth-core-dataframe/urth-core-dataframe.html
@@ -132,25 +132,25 @@ Example:
         },
 
         created: function(){
-            console.debug('urth-core-datafram created', arguments);
+            this._debug('urth-core-datafram created', arguments);
             this.createModel('urth.widgets.widget_dataframe.DataFrame');
         },
 
         ready: function() {
-            console.debug("urth-core-dataframe ready");
+            this._debug("urth-core-dataframe ready");
         },
 
         /*
          * onModelReady is invoked when have created the model portion of the widget
          */
         onModelReady: function(){
-            console.debug('urth-core-dataframe onModelReady');
+            this._debug('urth-core-dataframe onModelReady');
 
             var syncData = {
                 variable_name: this.ref,
                 limit: this.limit
             }
-            console.debug('urth-core-dataframe sending initial sync', syncData);
+            this._debug('urth-core-dataframe sending initial sync', syncData);
             this.sync(syncData);
 
             this.refresh();
@@ -161,7 +161,7 @@ Example:
          * the Backbone model changes.
          */
         onModelValueChange: function(newVal){
-            console.debug( "urth-core-dataframe onModelValueChange", newVal );
+            this._debug( "urth-core-dataframe onModelValueChange", newVal );
             this._setValue(newVal || {data:[]});
         },
 
@@ -196,7 +196,7 @@ Example:
             }
 
             this.debounce(jName, function(){
-              console.debug("urth-core-dataframe sending sync message...");
+              this._debug("urth-core-dataframe sending sync message...");
               this.send({ "event": "sync" });
             }.bind(this), 200);
         },
@@ -231,7 +231,7 @@ Example:
         },
 
         _onLimitChange: function(){
-            console.debug('urth-core-dataframe sending new limit value', this.limit);
+            this._debug('urth-core-dataframe sending new limit value', this.limit);
             this.sync({limit: this.limit});
             this.refresh();
         }

--- a/elements/urth-core-function/test/urth-core-function.html
+++ b/elements/urth-core-function/test/urth-core-function.html
@@ -61,8 +61,8 @@
              */
             sinon.stub(Urth["urth-core-function"].prototype, "createModel");
             sinon.stub(Urth["urth-core-function"].prototype, "displayErrorMessage");
-            sinon.stub(Urth.ExecutionCompleteBehavior, "ready");
-            sinon.stub(Urth.ExecutionCompleteBehavior, "detached");
+            sinon.stub(Urth.ExecutionCompleteBehavior[0], "ready");
+            sinon.stub(Urth.ExecutionCompleteBehavior[0], "detached");
         });
 
         // STEP 5: Define suite(s) and tests.

--- a/elements/urth-core-function/urth-core-function.html
+++ b/elements/urth-core-function/urth-core-function.html
@@ -145,12 +145,12 @@ Note that when using the 'click' event approach described above in #3, a click o
             },
 
             created: function(){
-                console.debug('urth-core-function created', arguments);
+                this._debug('urth-core-function created', arguments);
                 this.createModel('urth.widgets.widget_function.Function');
             },
 
             ready: function() {
-                console.debug('urth-core-function ready');
+                this._debug('urth-core-function ready');
 
                 if( !this.args ){
                     //sync with the attributes
@@ -162,13 +162,13 @@ Note that when using the 'click' event approach described above in #3, a click o
              * onModelReady is invoked when have created the model portion of the widget
              */
             onModelReady: function(){
-                console.debug('urth-core-function onModelReady');
+                this._debug('urth-core-function onModelReady');
 
                 var syncData = {
                     function_name: this.ref,
                     limit: this.limit
                 }
-                console.debug('urth-core-function sending initial sync', syncData);
+                this._debug('urth-core-function sending initial sync', syncData);
                 this.sync(syncData);
             },
 
@@ -177,13 +177,13 @@ Note that when using the 'click' event approach described above in #3, a click o
              * the Backbone model changes.
              */
             onModelResultChange: function(newVal){
-                console.debug( 'urth-core-function onModelResultChange', newVal );
+                this._debug( 'urth-core-function onModelResultChange', newVal );
                 //Using _setName function because we want result to be read-pnly to the outside world
                 this._setResult( newVal );
             },
 
             onModelSignatureChange: function(newVal){
-                console.debug('urth-core-function onModelSignatureChange', newVal);
+                this._debug('urth-core-function onModelSignatureChange', newVal);
                 this._setSignature( newVal );
             },
 
@@ -191,7 +191,7 @@ Note that when using the 'click' event approach described above in #3, a click o
                 if(this._syncing)
                     return;
 
-                console.debug('urth-core-function _onArgsChanged', rec);
+                this._debug('urth-core-function _onArgsChanged', rec);
                 if( rec.path === 'args' ){
                     //entire parameter map changed
                     this._syncParamAttributes(rec.value);
@@ -203,7 +203,7 @@ Note that when using the 'click' event approach described above in #3, a click o
                     var param =  matches.length === 2 ? matches[1] : undefined;
 
                     if( param ){
-                        console.debug('urth-core-function got change for param', param);
+                        this._debug('urth-core-function got change for param', param);
                         //reflect on the attibutes
                         var params = {};
                         var newVal = rec.base[param];
@@ -256,11 +256,13 @@ Note that when using the 'click' event approach described above in #3, a click o
                 }
 
                 this.debounce(jName, function(){
-                    console.debug("urth-core-function invoking...");
+                    var argsToSend = this._serializeParamsForSend();
+
+                    this._info("urth-core-function invoking with ", argsToSend);
 
                     this.send({
                         event: 'invoke',
-                        args: this._serializeParamsForSend()
+                        args: argsToSend
                     });
                 }.bind(this), this.delay);
             },
@@ -351,7 +353,7 @@ Note that when using the 'click' event approach described above in #3, a click o
             },
 
             _onParameterChange: function( argName, argValue ){
-                console.debug("urth-core-function _onParameterChange", argName, argValue);
+                this._debug("urth-core-function _onParameterChange", argName, argValue);
 
                 if (this.auto) {
                     this._tryInvoke();
@@ -359,7 +361,7 @@ Note that when using the 'click' event approach described above in #3, a click o
             },
 
             _onLimitChange: function(limit){
-                console.debug('urth-core-function _onLimitChange sending new limit value', this.limit);
+                this._debug('urth-core-function _onLimitChange sending new limit value', this.limit);
                 this.sync({limit: limit});
                 this._tryInvoke();
             },
@@ -371,7 +373,7 @@ Note that when using the 'click' event approach described above in #3, a click o
              *
              */
             _onSignatureChange: function(sig){
-                console.debug('urth-core-function _onSignatureChange got new signature', sig);
+                this._debug('urth-core-function _onSignatureChange got new signature', sig);
                 this._clearErrorMessages();
                 this.resetDynamicProperties();
 
@@ -428,14 +430,14 @@ Note that when using the 'click' event approach described above in #3, a click o
              * @method refresh
              */
             refresh: function() {
-                console.debug("urth-core-function sending sync message...");
+                this._debug("urth-core-function sending sync message...");
                 this.send({ "event": "sync" });
             },
 
             _createArgChangeHandler: function(param){
 
                 return function(newVal){
-                    console.log('urth-core-function handling change to', param);
+                    this._debug('urth-core-function handling change to', param);
 
                     if(this._syncing)
                         return;
@@ -456,7 +458,7 @@ Note that when using the 'click' event approach described above in #3, a click o
                     this.invoke(true);
                 }
                 else {
-                    console.warn('urth-core-function tried to invoke but arguments are not in valid state', this.args);
+                    this._warn('urth-core-function tried to invoke but arguments are not in valid state', this.args);
                 }
             },
 

--- a/elements/urth-core-import/urth-core-import-broker.html
+++ b/elements/urth-core-import/urth-core-import-broker.html
@@ -4,8 +4,6 @@
 -->
 <link rel="import" href="../polymer/polymer.html">
 <link rel="import" href="../promise-polyfill/promise-polyfill-lite.html">
-<link rel="import" href="../urth-core-behaviors/jupyter-widget-behavior.html">
-<link rel="import" href="../urth-core-behaviors/jupyter-kernel-observer.html">
 <link rel="import" href="../urth-core-storage/urth-core-storage.html">
 
 <!--

--- a/elements/urth-core-import/urth-core-import.html
+++ b/elements/urth-core-import/urth-core-import.html
@@ -5,6 +5,7 @@
 <link rel='import' href='../polymer/polymer.html'>
 <link rel='import' href='../iron-ajax/iron-ajax.html'>
 <link rel='import' href='../urth-core-behaviors/jupyter-notebook-env.html'>
+<link rel="import" href="../urth-core-behaviors/logging-behavior.html">
 <link rel='import' href='./urth-core-import-broker.html'>
 
 <!--
@@ -103,7 +104,10 @@
             }
         },
 
-        behaviors: [Urth.JupyterNotebookEnv],
+        behaviors: [
+            Urth.JupyterNotebookEnv,
+            Urth.LoggingBehavior
+        ],
 
         listeners: {
             'load': '_onLinkLoad'
@@ -133,14 +137,14 @@
 
         _downloadPackage: function(successCB, errorCB) {
             if (this.debug) {
-                console.debug(LOG_TAG + 'Sending server request to install ' + this.package);
+                this._debug(LOG_TAG + 'Sending server request to install ' + this.package);
             }
 
             // Listen to the 'response' event to handle the ajax POST return value.
             this.$.ajaxPost.addEventListener('response', function(response) {
                 if (response && response.detail.status === 200) {
                     if (this.debug) {
-                        console.debug(LOG_TAG + 'Successfully installed ' + this.package);
+                        this._debug(LOG_TAG + 'Successfully installed ' + this.package);
                     }
 
                     // Add a dummy parameter to the url to force the browser
@@ -202,14 +206,14 @@
         },
 
         _onLoadError: function(msg) {
-            console.warn(LOG_TAG + msg);
+            this._warn(LOG_TAG + msg);
             this.fire('importerror', { msg: msg });
         },
 
         _onLoadSuccess: function() {
             this.fire('load');
             if (this.debug) {
-                console.debug(LOG_TAG + 'Successfully imported ' + this.href);
+                this._debug(LOG_TAG + 'Successfully imported ' + this.href);
             }
         },
 

--- a/elements/urth-core-storage/urth-core-storage.html
+++ b/elements/urth-core-storage/urth-core-storage.html
@@ -3,6 +3,7 @@
 # Distributed under the terms of the Modified BSD License.
 -->
 <link rel="import" href="../polymer/polymer.html">
+<link rel="import" href="../urth-core-behaviors/logging-behavior.html">
 
 <!--
  Provides an API to persist key value pairs.
@@ -42,7 +43,7 @@
                 localStorage.removeItem(STORAGE_PREFIX);
                 return true;
             } catch(e) {
-                console.debug('Storage is disabled. Client state is not persisted.');
+                this._debug('Storage is disabled. Client state is not persisted.');
                 return false;
             }
         }
@@ -72,6 +73,8 @@
                     value: '__default__'
                 }
             },
+
+            behaviors: [Urth.LoggingBehavior],
 
             /**
              * Removes all of the keys for the configured collection from
@@ -146,7 +149,7 @@
                             localStorage.setItem(this._getPrefixedKey(key),
                                 JSON.stringify(value));
                         } catch(e) {
-                            console.error('Failed to save ' + key + ' to storage.', e);
+                            this._error('Failed to save ' + key + ' to storage.', e);
                         }
                     } else {
                         this.remove(key);

--- a/elements/urth-core-watch/urth-core-watch.html
+++ b/elements/urth-core-watch/urth-core-watch.html
@@ -3,6 +3,7 @@
 # Distributed under the terms of the Modified BSD License.
 -->
 <link rel="import" href="../polymer/polymer.html">
+<link rel="import" href="../urth-core-behaviors/logging-behavior.html">
 <!--
 Creates an element that listens to changes to the `value` property. When it changes, it fires 'watch_notify' custom
 event on child elements.
@@ -48,12 +49,14 @@ Example: _One or more children. urth-core-function and urth-core-dataframe suppo
                 value: Object
             },
 
+            behaviors: [Urth.LoggingBehavior],
+
             observers: [
                 '_valueChanged(value.*)'
             ],
 
             _valueChanged: function() {
-                console.log('urth-core-watch: valueChanged');
+                this._debug('urth-core-watch: valueChanged');
                 for (var i = 0, iLen = this.childNodes.length; i < iLen; i++) {
                     this.fire( 'watch_notify', null, {
                         node: this.childNodes[i]

--- a/elements/urth-viz-chart/urth-viz-chart-common-behavior.html
+++ b/elements/urth-viz-chart/urth-viz-chart-common-behavior.html
@@ -9,6 +9,7 @@
 <link rel="import" href="../urth-viz-col/urth-viz-col.html">
 <link rel="import" href="../urth-viz-behaviors/urth-viz-selection-behavior.html">
 <link rel="import" href="../urth-core-behaviors/error-display-behavior.html">
+<link rel="import" href="../urth-core-behaviors/logging-behavior.html">
 
 <!-- import the nvd3 stylesheet into the main page as well as the shadow dom
      because the nvtooltip is a child of BODY -->
@@ -196,7 +197,7 @@
             }
 
             if (this.columns.length && datarows[0] && this.columns.length != datarows[0].length) {
-                console.warn('Warning: arity of columns does not match data');
+                this._warn('Warning: arity of columns does not match data');
             }
 
             var columnSettings = this.columnSettings;
@@ -651,7 +652,8 @@
         Polymer.IronResizableBehavior,
         Urth.VizSelectionBehavior,
         Urth.DisplayErrorBehavior,
-        Urth.VizChartCommonBehaviorImpl
+        Urth.VizChartCommonBehaviorImpl,
+        Urth.LoggingBehavior
     ];
 
 })();

--- a/elements/urth-viz-ipywidget/test/urth-viz-ipywidget.html
+++ b/elements/urth-viz-ipywidget/test/urth-viz-ipywidget.html
@@ -57,8 +57,8 @@
              */
             createModel = sinon.stub(Urth["urth-viz-ipywidget"].prototype, "createModel");
             sinon.stub(Urth["urth-viz-ipywidget"].prototype, "displayErrorMessage");
-            sinon.stub(Urth.ExecutionCompleteBehavior, "ready");
-            sinon.stub(Urth.ExecutionCompleteBehavior, "detached");
+            sinon.stub(Urth.ExecutionCompleteBehavior[0], "ready");
+            sinon.stub(Urth.ExecutionCompleteBehavior[0], "detached");
             sinon.stub(Urth["urth-viz-ipywidget"].prototype, "onKernelReady");
         });
 

--- a/elements/urth-viz-ipywidget/urth-viz-ipywidget.html
+++ b/elements/urth-viz-ipywidget/urth-viz-ipywidget.html
@@ -95,7 +95,7 @@ names for these properties have the form `trait-<name of trait>`.
             ],
 
             onKernelReady: function(kernel){
-                console.debug('urth-viz-ipywidget onKernelReady', arguments);
+                this._debug('urth-viz-ipywidget onKernelReady', arguments);
 
                 //Need to know the kernel language to continue creation
                 kernel.get_info(this._onKernelInfo.bind(this))
@@ -112,7 +112,7 @@ names for these properties have the form `trait-<name of trait>`.
             },
 
             ready: function() {
-                console.debug('urth-viz-ipywidget ready');
+                this._debug('urth-viz-ipywidget ready');
 
                 if( !this.traits ){
                     //sync with the attributes
@@ -125,18 +125,18 @@ names for these properties have the form `trait-<name of trait>`.
              * kernel side the value of `ref`.
              */
             onModelReady: function(){
-                console.debug('urth-viz-ipywidget onModelReady');
+                this._debug('urth-viz-ipywidget onModelReady');
 
                 var syncData = {
                     widget_name: this.ref
                 }
-                console.debug('urth-viz-ipywidget sending initial sync', syncData);
+                this._debug('urth-viz-ipywidget sending initial sync', syncData);
                 this.sync(syncData);
             },
 
 
             onModelIdChange: function(modelid){
-                console.debug('urth-viz-ipywidget onModelIdChange', modelid);
+                this._debug('urth-viz-ipywidget onModelIdChange', modelid);
                 this._setModelId(modelid);
             },
 
@@ -154,7 +154,7 @@ names for these properties have the form `trait-<name of trait>`.
                 if(this._syncing)
                     return;
 
-                console.debug('urth-viz-ipywidget _onTraitPropertyChanged', rec);
+                this._debug('urth-viz-ipywidget _onTraitPropertyChanged', rec);
                 if( rec.path === 'traits' ){
                     //entire parameter map changed
                     this._syncTraitProperty(rec.value);
@@ -166,7 +166,7 @@ names for these properties have the form `trait-<name of trait>`.
                     var trait =  matches.length === 2 ? matches[1] : undefined;
 
                     if( trait ){
-                        console.debug('urth-viz-ipywidget got change for trait', trait);
+                        this._debug('urth-viz-ipywidget got change for trait', trait);
                         //reflect on the attibutes
                         var traits = {};
                         var newVal = rec.base[trait];
@@ -245,7 +245,7 @@ names for these properties have the form `trait-<name of trait>`.
             },
 
             _onTraitChange: function( argName, argValue ){
-                console.debug("urth-viz-ipywidget _onTraitChange", argName, argValue);
+                this._debug("urth-viz-ipywidget _onTraitChange", argName, argValue);
 
                 if( this.isConnected() ){
                     this.widgetModel.set(argName, argValue);
@@ -260,7 +260,7 @@ names for these properties have the form `trait-<name of trait>`.
              *
              */
             _onWidgetModelChange: function(){
-                console.debug('urth-viz-ipywidget _onWidgetModelChange');
+                this._debug('urth-viz-ipywidget _onWidgetModelChange');
                 this._clearErrorMessages();
 
                 //hook listener to model changes
@@ -277,7 +277,7 @@ names for these properties have the form `trait-<name of trait>`.
             },
 
             _setupTraitProperties: function(widgetTraits){
-                console.debug('urth-viz-ipywidget _setupTraitProperties', widgetTraits);
+                this._debug('urth-viz-ipywidget _setupTraitProperties', widgetTraits);
                 this.resetDynamicProperties();
 
                 //get the traits to expose them as properties
@@ -338,7 +338,7 @@ names for these properties have the form `trait-<name of trait>`.
 
             _createWidgetView: function(){
                 this.model.widget_manager.create_view(this.widgetModel).then( function(v){
-                    console.log( "Created ipywidget view", v);
+                    this._log( "Created ipywidget view", v);
                     Polymer.dom(this.root).innerHTML = ''; //clearing area first
                     Polymer.dom(this.root).appendChild(v.el);
                 }.bind(this))
@@ -351,14 +351,14 @@ names for these properties have the form `trait-<name of trait>`.
              * @method refresh
              */
             refresh: function() {
-                console.debug("urth-viz-ipywidget sending sync message...");
+                this._debug("urth-viz-ipywidget sending sync message...");
                 this.send({ "event": "sync" });
             },
 
             _createTraitChangeHandler: function(param){
 
                 return function(newVal){
-                    console.log('urth-viz-ipywidget handling change to', param);
+                    this._log('urth-viz-ipywidget handling change to', param);
 
                     if(this._syncing)
                         return;

--- a/etc/docs/urth-elements.html
+++ b/etc/docs/urth-elements.html
@@ -6,6 +6,7 @@
 <link rel='import' href='../../bower_components/urth-core-behaviors/jupyter-kernel-observer.html'>
 <link rel='import' href='../../bower_components/urth-core-behaviors/jupyter-save-behavior.html'>
 <link rel='import' href='../../bower_components/urth-core-behaviors/jupyter-widget-behavior.html'>
+<link rel='import' href='../../bower_components/urth-core-behaviors/logging-behavior.html'>
 <link rel='import' href='../../bower_components/urth-core-bind/urth-core-bind.html'>
 <link rel='import' href='../../bower_components/urth-core-channel/urth-core-channel.html'>
 <link rel='import' href='../../bower_components/urth-core-channel/urth-core-channel-broker.html'>

--- a/nb-extension/js/widgets/DeclWidgetModel.js
+++ b/nb-extension/js/widgets/DeclWidgetModel.js
@@ -21,7 +21,6 @@ define(["jupyter-js-widgets"], function(widgets) {
          * create model.
          */
         request_state: function(callbacks) {
-            console.trace( "Empty implementation of request_state()");
             return Promise.resolve(this);
         },
 


### PR DESCRIPTION
Fixes #349  

This PR implements a behavior to encapsulate logging support. It exposes a `log` property that can be used to turn on individual levels of logging. The default is to be silent.

Also added reading `Urth.debug` from the global to turn on full logging from one place.
