### PR TITLE
FIX #374: Executing `bower` in Windows through `cmd.exe`.

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ Watch from minute 21 to 41 of the [September 1st Jupyter meeting video recording
 
 * Jupyter Notebook 4.0.x, 4.1.x, or 4.2.x running on Python 3.x or Python 2.7.x (see the [0.1.x branch](https://github.com/jupyter-incubator/declarativewidgets/tree/0.1.x) for IPython Notebook 3.2.x compatibility)
 * [IPywidgets](https://github.com/ipython/ipywidgets) 4.1.x and 5.1.1+ (R and Scala support not available for 5.0.0 nor 5.1.0)
-* Bower - Necessary for installing 3rd party elements straight out of notebook
+* Bower, git - Necessary for installing 3rd party elements straight out of notebook
 
 ##### Optional Requirements based on language support
 * Apache Toree for access to Spark using Scala

--- a/nb-extension/python/urth/widgets/ext/urth_import.py
+++ b/nb-extension/python/urth/widgets/ext/urth_import.py
@@ -63,12 +63,17 @@ class UrthImportHandler(RequestHandler):
 # Executes bower install requests in a subprocess and returns 0 for success
 # and non-zero for an error.
 def do_install(package_name):
-    logger.info('Installing {0}'.format(package_name))
+    logger.info('Installing %r', package_name)
+    args = ['bower', 'install', package_name, '--allow-root',
+            '--config.interactive=false', '--production', '--quiet']
+    # In Windows`bower` is not an `.exe` (see #373)
+    if os.name == 'nt':
+        args = ['cmd', '/C'] + args
     try:
-        subprocess.check_call(['bower', 'install', package_name, '--allow-root',
-                '--config.interactive=false', '--production', '--quiet'],
-                cwd=widgets_dir)
+        subprocess.check_call(args, cwd=widgets_dir)
     except subprocess.CalledProcessError as e:
+        logger.error("Failed installing %r into %r with cmd:\n  %s\n  due to: %s", 
+                     package_name, widgets_dir, args, e)
         return -1
 
     return 0


### PR DESCRIPTION
- Update docs about `git` requirement.
- Improve logging and error-reporting when executing `bower`.

Fixes #374 
