### PR TITLE
Upped the upper bound of polymer to 1.5.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,7 +16,7 @@ services:
   - docker
 
 addons:
-  firefox: "latest"
+  firefox: "46.0"
   sauce_connect:
     no_ssl_bump_domains: all
   hosts:

--- a/bower.json
+++ b/bower.json
@@ -19,7 +19,7 @@
   ],
   "private": true,
   "dependencies": {
-    "polymer": "Polymer/polymer#>=1.2.4 <1.4.1",
+    "polymer": "Polymer/polymer#>=1.2.4 <=1.5.0",
     "webcomponentsjs": "^0.7.2"
   },
   "devDependencies": {


### PR DESCRIPTION
Builds are failing because some dependencies are now requesting to polymer 1.5.0. This PR increases the upper bound restriction of the project to include polymer 1.5.
