### PR TITLE
Serialize dates and display column types

### DIFF
--- a/elements/urth-core-dataframe/urth-core-dataframe.html
+++ b/elements/urth-core-dataframe/urth-core-dataframe.html
@@ -125,6 +125,15 @@ Example:
             },
 
             /**
+             * Column type metadata for the DataFrame
+             */
+             columnTypes: {
+                type: Array,
+                computed: '_columnTypes(value)',
+                notify: true
+             },
+
+            /**
              * An Array containing the data rows of the DataFrame. If 'row-as-object` is false, this
              * property will contain a 2D Array where the outer Array contains each row and the inner Array contains
              * the values for each column in the order defined by the `columns` property. If 'row-as-object` is true,
@@ -272,7 +281,26 @@ Example:
          */
         onModelValueChange: function(newVal){
             this._debug( "urth-core-dataframe onModelValueChange", newVal );
+            newVal = this._deserializeColumnTypes(newVal);
             this._setValue(newVal || {data:[]});
+        },
+
+        /*
+         * Returns the deserialized DataFrame reconstructed via the column_types
+         * @param df - the serialized DataFrame
+         * @return the reconstructed DataFrame
+         */
+        _deserializeColumnTypes: function(df) {
+            for (var i=0; i<df.column_types.length; i++) {
+                //if this column is of type date convert the string content to a date object
+                if(df.column_types[i] === "datetime64[ns]" || df.column_types[i] === "Date"
+                    || df.column_types[i] === "TimestampType") {
+                    for (var j=0; j<df.data.length; j++) {
+                        df.data[j][i] = new Date(df.data[j][i]);
+                    }
+                }
+            }
+            return df;
         },
 
         /* 
@@ -336,6 +364,16 @@ Example:
          */
         _columns: function(df){
             return df.columns;
+        },
+
+        /**
+         * Returns the type information of the serialized Dataframe
+         * @param df - the serialized DataFrame
+         * @return the types array
+         * @private
+         */
+        _columnTypes: function(df){
+            return df.column_types;
         },
 
         /**

--- a/elements/urth-core-dataframe/urth-core-dataframe.html
+++ b/elements/urth-core-dataframe/urth-core-dataframe.html
@@ -105,6 +105,7 @@ Example:
              * The serialized representation of the DataFrame `ref`. The structure contains:
              * {
              *  columns: Array of column names
+             *  column_types: Array of column type names
              *  data: 2D Array of rows with column values
              *  index: Array with index values
              * }
@@ -126,6 +127,7 @@ Example:
 
             /**
              * Column type metadata for the DataFrame
+             * For internal use ONLY
              */
              columnTypes: {
                 type: Array,
@@ -281,20 +283,22 @@ Example:
          */
         onModelValueChange: function(newVal){
             this._debug( "urth-core-dataframe onModelValueChange", newVal );
-            newVal = this._deserializeColumnTypes(newVal);
+            newVal = this._deserializeDateTypes(newVal || {data:[]});
             this._setValue(newVal || {data:[]});
         },
 
         /*
-         * Returns the deserialized DataFrame reconstructed via the column_types
+         * Returns the dataFrame with deserialized Date types of the dataFrame reconstructed via the column_types
          * @param df - the serialized DataFrame
          * @return the reconstructed DataFrame
          */
-        _deserializeColumnTypes: function(df) {
+        _deserializeDateTypes: function(df) {
+            if (!df.column_types || !df.data) {
+                return df;
+            }
             for (var i=0; i<df.column_types.length; i++) {
-                //if this column is of type date convert the string content to a date object
-                if(df.column_types[i] === "datetime64[ns]" || df.column_types[i] === "Date"
-                    || df.column_types[i] === "TimestampType") {
+                //If this column is of type date convert the string content to a date object
+                if(df.column_types[i] === "Date") {
                     for (var j=0; j<df.data.length; j++) {
                         df.data[j][i] = new Date(df.data[j][i]);
                     }
@@ -369,7 +373,7 @@ Example:
         /**
          * Returns the type information of the serialized Dataframe
          * @param df - the serialized DataFrame
-         * @return the types array
+         * @return the types array, where each element is a type name of that particular column
          * @private
          */
         _columnTypes: function(df){

--- a/etc/docs/site/usage-docs/Using-DataFrames.md
+++ b/etc/docs/site/usage-docs/Using-DataFrames.md
@@ -19,6 +19,7 @@ Once the element finds the DataFrame in the kernel, it get the data and makes it
 	```javascript
 {
    columns: [], //array of column names
+   column_types: [], //array of column type names (Note for internal use only)
    data: [[]], //2 dimensional array with the data. The outer array holds each row.
    index: [] //index value for each row (partial support)  
 }
@@ -48,6 +49,8 @@ OR
 	```
 
 * The `columns` property has an Array of column names
+
+* The `columnTypes` property has an Array of column type names (Note for internal use only)
 
 All property can be used in data bindings to render the data. The example above shows the data displayed as a set of cards, but the same data can be visualize using many of the `<urth-viz-*>` elements.
 

--- a/etc/notebooks/examples/urth-core-dataframe.ipynb
+++ b/etc/notebooks/examples/urth-core-dataframe.ipynb
@@ -37,7 +37,9 @@
    "outputs": [],
    "source": [
     "%%html\n",
-    "<link rel=\"stylesheet\" type=\"text/css\" href=\"bcard.css\">"
+    "<link rel=\"stylesheet\" type=\"text/css\" href=\"bcard.css\">\n",
+    "<link rel='import' href='urth_components/urth-viz-table/urth-viz-table.html'\n",
+    "        is='urth-core-import'>"
    ]
   },
   {
@@ -63,10 +65,11 @@
    "outputs": [],
    "source": [
     "aDataFrame1 = pd.DataFrame([\n",
-    "        [\"A\", 1],\n",
-    "        [\"B\", 2]\n",
-    "    ], columns=[\"Letter\", \"Number\"]\n",
-    ")"
+    "        [\"A\", 1, \"2013-01-01\"],\n",
+    "        [\"B\", 2, \"2013-01-02\"]\n",
+    "    ], columns=[\"Letter\", \"Number\", \"Date\"]\n",
+    ")\n",
+    "aDataFrame1['Date'] = pd.to_datetime(aDataFrame1['Date'])"
    ]
   },
   {
@@ -88,9 +91,12 @@
     "<template is=\"dom-bind\">\n",
     "    <urth-core-dataframe ref=\"aDataFrame1\" value=\"{{x}}\"></urth-core-dataframe>\n",
     "    <h4>{{x.columns}}</h4>\n",
+    "    <h4>{{x.column_types}}</h4>\n",
     "    <template is=\"dom-repeat\" items=\"{{x.data}}\">\n",
-    "        <div>{{item.0}}, {{item.1}}</div>\n",
+    "        <div>{{item.0}}, {{item.1}}, {{item.2}}</div>\n",
     "    </template>\n",
+    "    \n",
+    "    <urth-viz-table datarows=\"{{ x.data }}\" selection=\"{{sel}}\" columns=\"{{ x.columns }}\"></urth-viz-table>\n",
     "</template>"
    ]
   },
@@ -98,7 +104,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "#### Example 1.b Accessing the data using the `rows` and `columns` properties"
+    "#### Example 1.b Accessing the data using the `rows`, `columns`, and `columnTypes` properties"
    ]
   },
   {
@@ -111,7 +117,8 @@
    "source": [
     "%%html\n",
     "<template is=\"dom-bind\">\n",
-    "    <urth-core-dataframe ref=\"aDataFrame1\" rows=\"{{r}}\" columns=\"{{c}}\"></urth-core-dataframe>\n",
+    "    <urth-core-dataframe ref=\"aDataFrame1\" column-types=\"{{cTypes}}\" rows=\"{{r}}\" columns=\"{{c}}\"></urth-core-dataframe>\n",
+    "    <h4>{{cTypes}}</h4>\n",
     "    <h4>{{c}}</h4>\n",
     "    <template is=\"dom-repeat\" items=\"{{r}}\">\n",
     "        <div>{{item.0}}, {{item.1}}</div>\n",
@@ -302,11 +309,12 @@
    "outputs": [],
    "source": [
     "sparkDataFrame = sqlContext.createDataFrame(pd.DataFrame([\n",
-    "        [\"Jane\", \"Doe\",\"Scala Developer\", \"jane@ibm.com\", \"123-432-5431\", \"http://www.ibm.com/jane\"], \n",
-    "        [\"John\", \"Doe\",\"Spark Engineer\", \"john@ibm.com\", \"143-421-5411\", \"http://www.ibm.com/john\"],\n",
-    "        [\"Joe\", \"Smith\",\"Product Manager\", \"joe@ibm.com\", \"123-732-8421\", \"http://www.ibm.com/joe\"]\n",
-    "    ], columns=[\"First Name\", \"Last Name\", \"Role\", \"Email\", \"Phone Number\", \"Website\"]\n",
-    "))"
+    "        [\"Jane\", \"Doe\",\"Scala Developer\", \"jane@ibm.com\", \"123-432-5431\", \"http://www.ibm.com/jane\", \"2013-01-01\"], \n",
+    "        [\"John\", \"Doe\",\"Spark Engineer\", \"john@ibm.com\", \"143-421-5411\", \"http://www.ibm.com/john\", \"2013-01-02\"],\n",
+    "        [\"Joe\", \"Smith\",\"Product Manager\", \"joe@ibm.com\", \"123-732-8421\", \"http://www.ibm.com/joe\", \"2013-01-03\"]\n",
+    "    ], columns=[\"First Name\", \"Last Name\", \"Role\", \"Email\", \"Phone Number\", \"Website\", \"Date\"]\n",
+    "))\n",
+    "sparkDataFrame = sparkDataFrame.withColumn(\"Date\", sparkDataFrame[\"Date\"].cast(\"Date\"))"
    ]
   },
   {
@@ -329,6 +337,7 @@
     "            <span class=\"line phone-number\">{{item.3}}</span>\n",
     "            <span class=\"line email\">{{item.4}}</span>\n",
     "            <span class=\"line website\">{{item.5}}</span>\n",
+    "            <span class=\"line date\">{{item.6}}</span>\n",
     "        </div>\n",
     "        <div class=\"logo\"></div>\n",
     "      </div>\n",

--- a/etc/notebooks/examples/urth-core-dataframe.ipynb
+++ b/etc/notebooks/examples/urth-core-dataframe.ipynb
@@ -337,7 +337,6 @@
     "            <span class=\"line phone-number\">{{item.3}}</span>\n",
     "            <span class=\"line email\">{{item.4}}</span>\n",
     "            <span class=\"line website\">{{item.5}}</span>\n",
-    "            <span class=\"line date\">{{item.6}}</span>\n",
     "        </div>\n",
     "        <div class=\"logo\"></div>\n",
     "      </div>\n",

--- a/etc/notebooks/examples/urth-r-widgets.ipynb
+++ b/etc/notebooks/examples/urth-r-widgets.ipynb
@@ -216,7 +216,8 @@
     "Amount <- c(\"500\", \"456\", \"4526\")\n",
     "Bigger_Number <- c(\"1234325431\", \"1434215411\", \"1237328421\")\n",
     "Website <- c(\"http://javi.er\", \"http://www.ibm.us\", \"http://cooldevs.org/xavier\")\n",
-    "aDataFrame <- data.frame(First_Name, Last_Name, Role, Amount, Bigger_Number, Website)"
+    "Date <- c(as.Date(\"2013-01-01\"), as.Date(\"2013-01-02\"), as.Date(\"2013-01-03\"))\n",
+    "aDataFrame <- data.frame(First_Name, Last_Name, Role, Amount, Bigger_Number, Website, Date)"
    ]
   },
   {
@@ -244,6 +245,7 @@
     "            <span class='line phone-number'>{{sel.Amount}}</span>\n",
     "            <span class='line email'>{{sel.Bigger_Number}}</span>\n",
     "            <span class='line website'>{{sel.Website}}</span>\n",
+    "            <span class='line date'>{{sel.Date}}</span>\n",
     "        </div>\n",
     "        <div class='logo'></div>\n",
     "    </div>\n",
@@ -307,6 +309,7 @@
     "            <span class='line phone-number'>{{sel.Amount}}</span>\n",
     "            <span class='line email'>{{sel.Bigger_Number}}</span>\n",
     "            <span class='line website'>{{sel.Website}}</span>\n",
+    "            <span class='line date'>{{sel.Date}}</span>\n",
     "        </div>\n",
     "        <div class='logo'></div>\n",
     "    </div>\n",

--- a/etc/notebooks/examples/urth-scala-widgets.ipynb
+++ b/etc/notebooks/examples/urth-scala-widgets.ipynb
@@ -64,7 +64,9 @@
     "%%html\n",
     "<link rel=\"stylesheet\" type=\"text/css\" href=\"bcard.css\">\n",
     "<link rel='import' href='urth_components/paper-slider/paper-slider.html' \n",
-    "        is='urth-core-import' package='PolymerElements/paper-slider'>"
+    "        is='urth-core-import' package='PolymerElements/paper-slider'>\n",
+    "<link rel='import' href='urth_components/urth-viz-table/urth-viz-table.html'\n",
+    "        is='urth-core-import'>"
    ]
   },
   {
@@ -265,25 +267,27 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
-    "collapsed": true
+    "collapsed": false
    },
    "outputs": [],
    "source": [
-    "case class Contact(firstname: String, lastname: String, title: String, email: String, phone: String, web: String)"
+    "case class Contact(firstname: String, lastname: String, title: String, email: String, phone: String, web: String, date: String)"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
-    "collapsed": true
+    "collapsed": false
    },
    "outputs": [],
    "source": [
-    "val contacts = sqlContext.createDataFrame(Seq(\n",
-    "    Contact(\"Jane\", \"Doe\",\"Scala Developer\", \"jane@ibm.com\", \"123-432-5431\", \"http://www.ibm.com/jane\"), \n",
-    "    Contact(\"John\", \"Doe\",\"Spark Engineer\", \"john@ibm.com\", \"143-421-5411\", \"http://www.ibm.com/john\"),\n",
-    "    Contact(\"Joe\", \"Smith\",\"Product Manager\", \"joe@ibm.com\", \"123-732-8421\", \"http://www.ibm.com/joe\")))"
+    "import org.apache.spark.sql.types.DataTypes.TimestampType\n",
+    "var contacts = sqlContext.createDataFrame(Seq(\n",
+    "    Contact(\"Jane\", \"Doe\",\"Scala Developer\", \"jane@ibm.com\", \"123-432-5431\", \"http://www.ibm.com/jane\", \"2013-01-01\"), \n",
+    "    Contact(\"John\", \"Doe\",\"Spark Engineer\", \"john@ibm.com\", \"143-421-5411\", \"http://www.ibm.com/john\", \"2013-01-02\"),\n",
+    "    Contact(\"Joe\", \"Smith\",\"Product Manager\", \"joe@ibm.com\", \"123-732-8421\", \"http://www.ibm.com/joe\", \"2013-01-03\")))\n",
+    "contacts = contacts.withColumn(\"date\", contacts(\"date\").cast(TimestampType))"
    ]
   },
   {
@@ -298,6 +302,8 @@
     "<template is=\"dom-bind\">\n",
     "    <urth-core-dataframe ref=\"contacts\" value=\"{{x}}\" auto></urth-core-dataframe>\n",
     "    \n",
+    "    <urth-viz-table datarows=\"{{ x.data }}\" selection=\"{{sel}}\" columns=\"{{ x.columns }}\"></urth-viz-table>\n",
+    "\n",
     "    <template is=\"dom-repeat\" items=\"{{x.data}}\">\n",
     "      <div class=\"bcard\">\n",
     "        <div class=\"info\">\n",
@@ -306,6 +312,7 @@
     "            <span class=\"line phone-number\">{{item.3}}</span>\n",
     "            <span class=\"line email\">{{item.4}}</span>\n",
     "            <span class=\"line website\">{{item.5}}</span>\n",
+    "            <span class=\"line date\">{{item.6}}</span>\n",
     "        </div>\n",
     "        <div class=\"logo\"></div>\n",
     "      </div>\n",

--- a/kernel-r/declarativewidgets/R/serializers.r
+++ b/kernel-r/declarativewidgets/R/serializers.r
@@ -88,6 +88,7 @@ Spark_DataFrame_Serializer <- R6Class(
             df <- collect(limit(obj, row_limit))
             json <- list()
             json[['columns']] <- colnames(df)
+            json[['column_types']] <- get_df_column_types(df)
             json[['data']] <- self$df_to_lists(df)
             json[['index']] <- list(1:nrow(df))
             return (json)

--- a/kernel-r/declarativewidgets/R/serializers.r
+++ b/kernel-r/declarativewidgets/R/serializers.r
@@ -1,5 +1,23 @@
 #' @include serializer.r
 
+serialize_element <- function(elem) {
+    if(class(elem) == "Date") {
+        options(digits.secs=3)
+        return (format(elem, "%Y-%m-%dT%H:%M:%OSZ"))
+    } else {
+        return (as.character(elem))
+    }
+}
+
+get_df_column_types <- function(df) {
+    class_info <- lapply(aDataFrame, class)
+    type_info <- list()
+    for (i in class_info) {
+        type_info <- append(type_info, i)
+    }
+    return (unlist(type_info))
+}
+
 DataFrame_Serializer <- R6Class(
     'DataFrame_Serializer',
     inherit = Serializer,
@@ -19,7 +37,7 @@ DataFrame_Serializer <- R6Class(
             for(i in 1:min(limit, nrow(df))) {
                 row_elements <- list()
                 for(j in 1:ncol(df)) {
-                    row_elements <- append(row_elements, as.character(df[i,j]))
+                    row_elements <- append(row_elements, serialize_element(df[i,j]))
                 }
                 rows <- append(rows, list(row_elements))
             }
@@ -28,6 +46,7 @@ DataFrame_Serializer <- R6Class(
         serialize = function(obj, row_limit=100) {
             json <- list()
             json[['columns']] <- colnames(obj)
+            json[['column_types']] <- get_df_column_types(obj)
             json[['data']] <- self$df_to_lists(obj, row_limit)
             json[['index']] <- as.numeric(rownames(obj))
             return (json)
@@ -59,7 +78,7 @@ Spark_DataFrame_Serializer <- R6Class(
             for(i in 1:nrow(df)) {
                 row_elements <- list()
                 for(j in 1:ncol(df)) {
-                    row_elements <- append(row_elements, as.character(df[i,j]))
+                    row_elements <- append(row_elements, serialize_element(df[i,j]))
                 }
                 rows <- append(rows, list(row_elements))
             }

--- a/kernel-scala/src/main/scala/declarativewidgets/util/SerializationSupport.scala
+++ b/kernel-scala/src/main/scala/declarativewidgets/util/SerializationSupport.scala
@@ -10,6 +10,9 @@ import org.apache.toree.utils.LogLike
 import org.apache.spark.sql.DataFrame
 import play.api.libs.json._
 
+import org.apache.spark.sql.types.TimestampType
+import org.apache.spark.sql.types.DateType
+
 /**
  * Contains methods for serializing a variable based on its type.
  */
@@ -53,7 +56,14 @@ trait SerializationSupport extends LogLike {
     (df: DataFrame) => {
       val columns: Array[String] = df.columns
 
-      val column_types: Array[String] = df.schema.map(x => x.dataType.toString()).toArray
+      //https://spark.apache.org/docs/latest/api/java/org/apache/spark/sql/types/package-tree.html
+      //match possible date types the user may be using
+      val column_types: Array[String] = df.schema.map(
+                                        x => x.dataType match {
+                                          case timeStamp: TimestampType => "Date"
+                                          case date: DateType => "Date"
+                                          case _ =>  x.dataType.toString()
+                                        }).toArray
 
       val data: Array[Array[JsValue]] = df.toJSON.take(limit).map( jsonRow => toArray(Json.parse(jsonRow).as[JsObject], columns))
 

--- a/kernel-scala/src/main/scala/declarativewidgets/util/SerializationSupport.scala
+++ b/kernel-scala/src/main/scala/declarativewidgets/util/SerializationSupport.scala
@@ -53,12 +53,15 @@ trait SerializationSupport extends LogLike {
     (df: DataFrame) => {
       val columns: Array[String] = df.columns
 
+      val column_types: Array[String] = df.schema.map(x => x.dataType.toString()).toArray
+
       val data: Array[Array[JsValue]] = df.toJSON.take(limit).map( jsonRow => toArray(Json.parse(jsonRow).as[JsObject], columns))
 
       val index: Array[String] = (0 until data.length).map(_.toString).toArray
 
       Json.obj(
         "columns" -> columns,
+        "column_types" -> column_types,
         "index"   -> index,
         "data"    -> data
       )


### PR DESCRIPTION
[#383](https://github.com/jupyter-incubator/declarativewidgets/issues/383)
- Added a date type column to each of the three example notebooks dataframe example.
  - Python - delegates pyspark to use the pandas to json function we already had.
  - R - when serializing each element apply proper date formatting if the class is Date.
  - Scala - From [df.toJSON](https://github.com/jupyter-incubator/declarativewidgets/blob/0.5.3/kernel-scala/src/main/scala/urth/widgets/util/SerializationSupport.scala#L55) it returns an [rdd of strings](http://spark.apache.org/docs/latest/api/scala/index.html#org.apache.spark.sql.DataFrame), so by the time it gets to the client the date is already formatted.  When initing the df the user specifies the [DataType](https://spark.apache.org/docs/latest/api/java/org/apache/spark/sql/types/DataTypes.html) (applicable types are DateType and TimestampType).  df.toJson will create the string based off the type not the client, so one idea might be to create a custom column data type.  For reference the format of TimeStampType the closest was `2013-01-03 00:00:00.0`.
