### PR TITLE
Fix loading indicator on Chrome and IE/Edge.

### DIFF
--- a/elements/urth-core-bind/urth-core-bind.html
+++ b/elements/urth-core-bind/urth-core-bind.html
@@ -91,6 +91,7 @@
             ],
 
             created: function() {
+                this.showLoadingMsg(true);
                 this._createChannel();
             },
 
@@ -112,9 +113,9 @@
 
             showLoadingMsg: function(show) {
                 if (show) {
-                    Polymer.dom(this.root).classList.add('loading');
+                    Polymer.dom(this.root).classList.add('urth-loading');
                 } else {
-                    Polymer.dom(this).classList.remove('loading');
+                    Polymer.dom(this).classList.remove('urth-loading');
                 }
             },
 
@@ -133,7 +134,6 @@
                     var pendingImports = importBroker.getPendingImports().map(function(key) {
                         return key.completed;
                     });
-                    this.showLoadingMsg(true);
                     this._pendingImports = Promise.all(pendingImports);
                 } else {
                     this._pendingImports = Promise.resolve(true);

--- a/nb-extension/css/main.css
+++ b/nb-extension/css/main.css
@@ -1,10 +1,10 @@
-.loading { 
+.urth-loading {
 	display: block;
 	height: 5px;
 	position: relative;
 }
 
-.loading:before { 
+.urth-loading:before {
 	content: '';
 	display: block;
 	position: absolute;
@@ -16,39 +16,49 @@
 }
 
 /* code to stripe the bar */
-.loading:after {
+.urth-loading:after {
 	content: "";
 	position: absolute;
   	top: 0; left: 0; bottom: 0; right: 0;
-  	background-image: 
-	   -webkit-gradient(linear, 0 0, 100% 100%, 
-	      color-stop(.25, rgba(255, 255, 255, .5)), 
-	      color-stop(.25, transparent), color-stop(.5, transparent), 
-	      color-stop(.5, rgba(255, 255, 255, .5)), 
-	      color-stop(.75, rgba(255, 255, 255, .5)), 
-	      color-stop(.75, transparent), to(transparent)
-	   );
-	background-image: 
-		-moz-linear-gradient(
-		  -45deg, 
-	      rgba(255, 255, 255, .5) 25%, 
-	      transparent 25%, 
-	      transparent 50%, 
-	      rgba(255, 255, 255, .5) 50%, 
-	      rgba(255, 255, 255, .5) 75%, 
-	      transparent 75%, 
-	      transparent
-	   );
+	background-image: -webkit-gradient(
+		linear, 0 0, 100% 100%,
+		color-stop(.25, rgba(255, 255, 255, .5)),
+		color-stop(.25, transparent), color-stop(.5, transparent),
+		color-stop(.5, rgba(255, 255, 255, .5)),
+		color-stop(.75, rgba(255, 255, 255, .5)),
+		color-stop(.75, transparent), to(transparent)
+	);
+	background-image: -moz-linear-gradient(
+		-45deg,
+		rgba(255, 255, 255, .5) 25%,
+		transparent 25%,
+		transparent 50%,
+		rgba(255, 255, 255, .5) 50%,
+		rgba(255, 255, 255, .5) 75%,
+		transparent 75%,
+		transparent
+	);
+	background-image: linear-gradient(
+		-45deg,
+		rgba(255, 255, 255, .5) 25%,
+		transparent 25%,
+		transparent 50%,
+		rgba(255, 255, 255, .5) 50%,
+		rgba(255, 255, 255, .5) 75%,
+		transparent 75%,
+		transparent
+	);
 	z-index: 1;
 	-webkit-background-size: 50px 50px;
 	-moz-background-size: 50px 50px;
 	background-size: 50px 50px;
-	-webkit-animation: move 1s linear infinite;
-	-moz-animation: move 1s linear infinite;
+	-webkit-animation: urth-move-loading 1s linear infinite;
+	-moz-animation: urth-move-loading 1s linear infinite;
+	animation: urth-move-loading 1s linear infinite;
 	overflow: hidden;
 }
 
-@-webkit-keyframes move {
+@-webkit-keyframes urth-move-loading {
     0% {
        background-position: 0 0;
     }
@@ -57,7 +67,16 @@
     }
 }
 
-@-moz-keyframes move {
+@-moz-keyframes urth-move-loading {
+    0% {
+       background-position: 0 0;
+    }
+    100% {
+       background-position: 25px 25px;
+    }
+}
+
+@keyframes urth-move-loading {
     0% {
        background-position: 0 0;
     }


### PR DESCRIPTION
In a "Run All" scenario of a notebook on Chrome the loading progress indicator for `urth-core-bind` was not being displayed. This was likely introduced by the change to requiring the notebook to perform init of declarative widgets. Since Chrome contains a native implementation of HTML Imports, the imports on the page were blocking the `Polymer.RenderStatus.whenReady()` call in `dom-bind-behavior.html`. Prior to this change the progress bar was being displayed in the `_customRender` method if there were pending imports, but in this case all of the pending imports would have been resolved before `Polymer.RenderStatus.whenReady()` fires so the loading progress bar was never shown.

I've moved the display of the progress bar to the `created` method on `urth-core-bind` so it displays immediately. I have not noticed any "flickering" of the page if all dependencies are satisfied since Polymer delays the rendering of changes long enough not to detect the class change.

I've also made changes to the naming of classes and keyframes to make them more project specific and added some missing style rules to fix rendering of the progress indicator on IE/Edge.

Fixes #388
