### PR TITLE
Normalize the names of aggregate columns when performing grouped aggregations

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -454,7 +454,7 @@ docs: .watch-docs dist/docs
 	@echo "Serving docs at $(DOCURL):$(DOC_PORT)"
 	@bash -c "trap 'make clean-watch-docs' INT TERM ; npm run http-server -- dist/docs/site -p $(DOC_PORT)"
 
-all: init test-js-remote test-py-all test-scala sdist install-all system-test
+all: init test-js-remote test-py-all test-scala test-r sdist install-all system-test
 
 release: EXTRA_OPTIONS=-e PYPI_USER=$(PYPI_USER) -e PYPI_PASSWORD=$(PYPI_PASSWORD)
 release: PRE_SDIST=echo "[server-login]" > ~/.pypirc; echo "username:" ${PYPI_USER} >> ~/.pypirc; echo "password:" ${PYPI_PASSWORD} >> ~/.pypirc;

--- a/etc/notebooks/examples/urth-core-query.ipynb
+++ b/etc/notebooks/examples/urth-core-query.ipynb
@@ -274,7 +274,7 @@
     "        <urth-core-query-group by=\"medallion\">\n",
     "            <urth-core-query-agg op=\"sum\" col=\"total_amount\"></urth-core-query-agg>\n",
     "        </urth-core-query-group>\n",
-    "        <urth-core-query-sort by=\"total_amount_sum\" direction=\"{{topOrBottom}}\"></urth-core-query-sort>\n",
+    "        <urth-core-query-sort by=\"sum_total_amount\" direction=\"{{topOrBottom}}\"></urth-core-query-sort>\n",
     "    </urth-core-dataframe>\n",
     "    <paper-card style=\"width: 100%;\" heading=\"Earners\" elevation=\"1\">\n",
     "        <div class=\"card-content\">\n",

--- a/kernel-python/declarativewidgets/util/query/pandas.py
+++ b/kernel-python/declarativewidgets/util/query/pandas.py
@@ -95,4 +95,4 @@ def to_dict_agg(agg_array):
 
 
 def to_single_column_names(column_array):
-    return map(lambda col: col[:-1] if col.endswith('_') else col, ['_'.join(col).strip() for col in column_array])
+    return map(lambda col: col[1:] if col.startswith('_') else col, ['_'.join(col[::-1]).strip() for col in column_array])

--- a/kernel-python/declarativewidgets/util/query/spark.py
+++ b/kernel-python/declarativewidgets/util/query/spark.py
@@ -42,7 +42,10 @@ def handle_group( df, grp_expr ):
     group_cols = grp_expr['by']
     group_aggs = grp_expr['agg']
 
-    return df.groupby(group_cols).agg(*to_array_of_func_exprs(group_aggs))
+    #rename resultant column names to dataframe format i.e. sum(columnName) -> sum_columnName
+    renamed_columns = [group_cols] + [x['op'] + "_" + x['col'] for x in group_aggs]
+
+    return df.groupby(group_cols).agg(*to_array_of_func_exprs(group_aggs)).toDF(*renamed_columns)
 
 
 def handle_sort(df, sort_expr):

--- a/kernel-python/declarativewidgets/util/query/tests/test_pandas.py
+++ b/kernel-python/declarativewidgets/util/query/tests/test_pandas.py
@@ -38,8 +38,8 @@ class TestFunctions(unittest.TestCase):
 
         expected = [
             "col1",
-            "col2_count",
-            "col3_sum"
+            "count_col2",
+            "sum_col3"
         ]
 
         actual = to_single_column_names(arg_array)

--- a/kernel-r/declarativewidgets/R/queriers.r
+++ b/kernel-r/declarativewidgets/R/queriers.r
@@ -22,7 +22,7 @@ DataFrame_Querier <- R6Class(
             cols <- append(cols, temp_index)
             for (i in 1:length(grp_expr$agg$op)) {
                 temp_index <- (aggregate(df[,c(grp_expr$agg[2][,1][i])] ~ df[,c(as.character(grp_expr$by))], df, grp_expr$agg[1][,1][i])[2])
-                names(temp_index) <- paste(grp_expr$agg[2][,1][i], "_", grp_expr$agg[1][,1][i], sep="")
+                names(temp_index) <- paste(grp_expr$agg[1][,1][i], "_", grp_expr$agg[2][,1][i], sep="")
                 cols <- append(cols, temp_index)
             }
             new_df <- format(data.frame(cols))
@@ -52,7 +52,7 @@ Spark_DataFrame_Querier <- R6Class(
             for (i in 1:length(grp_expr$agg$op)) {
                 temp_expr <- paste(grp_expr$agg[1][,1][i], "(", grp_expr$agg[2][,1][i], ")", sep="")
                 agg_args <- append(agg_args, expr(temp_expr))
-                temp_name <- paste(grp_expr$agg[2][,1][i], "_", grp_expr$agg[1][,1][i], sep="")
+                temp_name <- paste(grp_expr$agg[1][,1][i], "_", grp_expr$agg[2][,1][i], sep="")
                 col_names <- append(col_names, temp_name)
             }
             new_df <- do.call(agg, agg_args)

--- a/kernel-r/declarativewidgets/tests/testthat/test_df_queries.R
+++ b/kernel-r/declarativewidgets/tests/testthat/test_df_queries.R
@@ -72,25 +72,25 @@ test_that("apply_query_groupby", {
 
     new_df <- querier$apply_query(df, query)
     expect_equal(nrow(new_df), 4)
-    expect_equal(as.numeric(new_df$numbers_sum[3]), 12)
-    expect_equal(as.numeric(new_df$numbers_mean[3]), 4)
+    expect_equal(as.numeric(new_df$sum_numbers[3]), 12)
+    expect_equal(as.numeric(new_df$mean_numbers[3]), 4)
 
     new_spark_df <- querier$apply_query(spark_df, query)
     expect_equal(nrow(collect(new_spark_df)), 4)
-    expect_equal(as.numeric(collect(new_spark_df)$numbers_sum[3]), 12)
-    expect_equal(as.numeric(collect(new_spark_df)$numbers_mean[3]), 4)
+    expect_equal(as.numeric(collect(new_spark_df)$sum_numbers[3]), 12)
+    expect_equal(as.numeric(collect(new_spark_df)$mean_numbers[3]), 4)
 })
 
 test_that("apply_query_groupby_and_filter", {
     groupby_and_filter_query_df <- "[{\"type\":\"filter\",\"expr\":\"letters == 'C'\"}, {\"type\":\"group\",\"expr\":{\"by\":[\"letters\"],\"agg\":[{\"op\":\"sum\",\"col\":\"numbers\"},{\"op\":\"mean\",\"col\":\"numbers\"}]}}]"
     new_df <- querier$apply_query(df, fromJSON(groupby_and_filter_query_df))
     expect_equal(nrow(new_df), 1)
-    expect_equal(as.numeric(new_df$numbers_sum[1]), 12)
-    expect_equal(as.numeric(new_df$numbers_mean[1]), 4)
+    expect_equal(as.numeric(new_df$sum_numbers[1]), 12)
+    expect_equal(as.numeric(new_df$mean_numbers[1]), 4)
 
     groupby_and_filter_query_spark_df <- "[{\"type\":\"filter\",\"expr\":\"letters = 'C'\"}, {\"type\":\"group\",\"expr\":{\"by\":[\"letters\"],\"agg\":[{\"op\":\"sum\",\"col\":\"numbers\"},{\"op\":\"mean\",\"col\":\"numbers\"}]}}]"
     new_spark_df <- querier$apply_query(spark_df, fromJSON(groupby_and_filter_query_spark_df))
     expect_equal(nrow(collect(new_spark_df)), 1)
-    expect_equal(as.numeric(collect(new_spark_df)$numbers_sum[1]), 12)
-    expect_equal(as.numeric(collect(new_spark_df)$numbers_mean[1]), 4)
+    expect_equal(as.numeric(collect(new_spark_df)$sum_numbers[1]), 12)
+    expect_equal(as.numeric(collect(new_spark_df)$mean_numbers[1]), 4)
 })

--- a/kernel-scala/src/main/scala/declarativewidgets/query/QuerySupport.scala
+++ b/kernel-scala/src/main/scala/declarativewidgets/query/QuerySupport.scala
@@ -55,8 +55,10 @@ trait QuerySupport extends LogLike {
 
       }
     )
-
-    df.groupBy(by:_*).agg(agg.head, agg.tail :_*)
+    //rename resultant column names to dataframe format i.e. sum(columnName) -> sum_columnName
+    val regex = "\\(".r
+    val renamedColumns = by.map(_.toString()) ++ agg.map(x => regex.replaceFirstIn(x.toString(), "_").dropRight(1))
+    df.groupBy(by:_*).agg(agg.head, agg.tail :_*).toDF(renamedColumns:_*)
   }
 
   /**

--- a/kernel-scala/src/test/scala/declarativewidgets/query/QuerySupportSpec.scala
+++ b/kernel-scala/src/test/scala/declarativewidgets/query/QuerySupportSpec.scala
@@ -72,16 +72,16 @@ class QuerySupportSpec extends FunSpec with Matchers with MockitoSugar with Befo
       val queryJson = Json.parse(query).asOpt[JsArray].getOrElse(new JsArray())
       val newDf = support.applyQuery(queryDf, queryJson)
       assert(newDf.count() == 4)
-      assert(newDf.select("sum(numbers)").rdd.map(r => r(0).asInstanceOf[Long]).collect()(2) == 12)
-      assert(newDf.select("mean(numbers)").rdd.map(r => r(0).asInstanceOf[Double]).collect()(2) == 4)
+      assert(newDf.select("sum_numbers").rdd.map(r => r(0).asInstanceOf[Long]).collect()(2) == 12)
+      assert(newDf.select("mean_numbers").rdd.map(r => r(0).asInstanceOf[Double]).collect()(2) == 4)
     }
     it("should apply_query_groupby_and_filter") {
       val query = """[{"type":"filter","expr":"letters = 'C'"}, {"type":"group","expr":{"by":["letters"],"agg":[{"op":"sum","col":"numbers"},{"op":"mean","col":"numbers"}]}}]"""
       val queryJson = Json.parse(query).asOpt[JsArray].getOrElse(new JsArray())
       val newDf = support.applyQuery(queryDf, queryJson)
       assert(newDf.count() == 1)
-      assert(newDf.select("sum(numbers)").rdd.map(r => r(0).asInstanceOf[Long]).collect()(0) == 12)
-      assert(newDf.select("mean(numbers)").rdd.map(r => r(0).asInstanceOf[Double]).collect()(0) == 4)
+      assert(newDf.select("sum_numbers").rdd.map(r => r(0).asInstanceOf[Long]).collect()(0) == 12)
+      assert(newDf.select("mean_numbers").rdd.map(r => r(0).asInstanceOf[Double]).collect()(0) == 4)
     }
   }
 }


### PR DESCRIPTION
Resolves #378 by changing the spark (scala/python/r) column names to the pandas format.
Need to make sure to update the [Using-DataFrames Wiki](https://github.com/jupyter-incubator/declarativewidgets/wiki/Using-DataFrames)

(c) Copyright IBM Corp. 2016
