### PR TITLE
Set Tar env variable for R dev_image install

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -441,7 +441,7 @@ ifdef SAUCE_USER_NAME
 	@BROWSER_LIST="$(BROWSER_LIST)" JUPYTER=$(JUPYTER) SPECS="$(SPECS)" BASEURL=$(BASEURL) $(MAKE) system-test-all-remote
 else ifdef TRAVIS
 	@echo 'Starting system integration tests locally on Travis...'
-	@BROWSER_LIST="firefox" JUPYTER=$(JUPYTER) SPECS="$(SPECS)" BASEURL=$(BASEURL) $(MAKE) system-test-all-local
+	@BROWSER_LIST="firefox" ALT_BROWSER_LIST="firefox" JUPYTER=$(JUPYTER) SPECS="$(SPECS)" BASEURL=$(BASEURL) $(MAKE) system-test-all-local
 else
 	@echo 'Starting system integration tests locally...'
 	@BROWSER_LIST="$(BROWSER_LIST)" JUPYTER=$(JUPYTER) SPECS="$(SPECS)" BASEURL=$(BASEURL) $(MAKE) system-test-all-local

--- a/etc/r/install.r
+++ b/etc/r/install.r
@@ -10,6 +10,7 @@
 
 temp_libPaths <- .libPaths()
 .libPaths(temp_libPaths[2])
+Sys.setenv(TAR = '/bin/tar')
 install.packages("devtools", repos='http://cran.us.r-project.org', quiet = TRUE)
 try(library(devtools), silent = TRUE)
 remove.packages("repr")


### PR DESCRIPTION
- When installing the IRKernel and it's dependencies using the devtools package an error `sh: 1: /bin/gtar: not found` occurred in the `dev_image` target.
- The most recent devtools release includes a change set that cause installations to use the tarball endpoint rather than zipball.  https://github.com/hadley/devtools/pull/1196
- This PR pins devtools to the release before that recent change set.
- Resolving what is wrong on the container level/why the tar issue occurred may be better, but need to look into that still.
- This will also all go away once comm changes get in an IRKernel release.  Discussion on that looks to have been started at https://github.com/IRkernel/IRkernel/issues/344
