### PR TITLE
Allow arbitrary function references in IPykernel

### DIFF
--- a/kernel-python/declarativewidgets/tests/test_widget_function.py
+++ b/kernel-python/declarativewidgets/tests/test_widget_function.py
@@ -1,0 +1,44 @@
+# (c) Copyright Jupyter Development Team
+
+import unittest
+
+try:
+    from unittest.mock import Mock
+except ImportError as e:
+    from mock import Mock
+
+from ipykernel.comm import Comm
+from declarativewidgets.widget_function import Function
+
+# Execute tests within an IPython instance
+from IPython.testing.globalipapp import get_ipython
+ip = get_ipython()
+
+
+class TestWidgetFunction(unittest.TestCase):
+    def setUp(self):
+        comm = Mock(spec=Comm)
+        self.fun = Function(comm=comm)
+
+    def test_the_function(self):
+        def mock_function(x):
+            return x + 2
+
+        ip.user_ns['mock_function'] = mock_function
+
+        self.fun.function_name = 'mock_function'
+
+        assert self.fun._the_function()(3) == 5
+
+    def test_the_function_object_scope(self):
+        class mock_class():
+            def mock_class_function(self, x):
+                return x + 3
+
+        mock_object = mock_class()
+
+        ip.user_ns['mock_object'] = mock_object
+
+        self.fun.function_name = 'mock_object.mock_class_function'
+
+        assert self.fun._the_function()(3) == 6

--- a/kernel-python/declarativewidgets/widget_function.py
+++ b/kernel-python/declarativewidgets/widget_function.py
@@ -9,6 +9,9 @@ from .util.functions import apply_with_conversion, signature_spec
 from .urth_widget import UrthWidget
 from .urth_exception import UrthException
 
+from functools import reduce
+
+
 class Function(UrthWidget):
     """
     A Widget for invoking a function on the kernel.
@@ -41,9 +44,9 @@ class Function(UrthWidget):
 
     def _the_function(self):
         try:
-            return eval(self.function_name, self.shell.user_global_ns,
-                        self.shell.user_ns)
-        except NameError:
+            name = self.function_name.split('.')
+            return reduce(lambda x, y: getattr(x, y), [self.shell.user_ns[name.pop(0)]] + name)
+        except (KeyError, AttributeError):
             raise UrthException("Invalid function name {}".format(
                 self.function_name))
 

--- a/kernel-python/declarativewidgets/widget_function.py
+++ b/kernel-python/declarativewidgets/widget_function.py
@@ -40,9 +40,10 @@ class Function(UrthWidget):
             self._sync_state()
 
     def _the_function(self):
-        if self.function_name in self.shell.user_ns:
-            return self.shell.user_ns[self.function_name]
-        else:
+        try:
+            return eval(self.function_name, self.shell.user_global_ns,
+                        self.shell.user_ns)
+        except NameError:
             raise UrthException("Invalid function name {}".format(
                 self.function_name))
 


### PR DESCRIPTION
Was only possible to refer to functions that were defined in the current scope (i.e. functions contained within some class/object were inaccessible). Fix this by using eval instead of accessing the IPykernel's user_ns dictionary directly.
