### PR TITLE
Added one line explore display function

### DIFF
--- a/etc/notebooks/examples/urth-r-widgets.ipynb
+++ b/etc/notebooks/examples/urth-r-widgets.ipynb
@@ -257,6 +257,24 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
+    "### DataFrame explorer"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "explore(\"aDataFrame\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
     "### Spark DataFrame widget"
    ]
   },

--- a/etc/notebooks/examples/urth-scala-widgets.ipynb
+++ b/etc/notebooks/examples/urth-scala-widgets.ipynb
@@ -324,6 +324,25 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
+    "### DataFrame explorer"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "import declarativewidgets.WidgetVisualizations.explore\n",
+    "explore(\"contacts\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
     "### Channels API\n",
     "\n",
     "Interact with `urth-core-bind` `channel` variables using the following API:"

--- a/etc/notebooks/examples/urth-viz-explorer.ipynb
+++ b/etc/notebooks/examples/urth-viz-explorer.ipynb
@@ -24,6 +24,7 @@
    "source": [
     "import pandas as pd\n",
     "import declarativewidgets as declwidgets\n",
+    "from declarativewidgets.widget_visualizations import explore\n",
     "\n",
     "declwidgets.init()"
    ]
@@ -37,7 +38,8 @@
    "outputs": [],
    "source": [
     "%%html\n",
-    "<link rel='import' href='urth_components/urth-viz-explorer/urth-viz-explorer.html' is='urth-core-import'>"
+    "<link rel='import' href='urth_components/urth-viz-explorer/urth-viz-vega-explorer.html' \n",
+    "        is='urth-core-import' package='ibm-et/urth-viz-vega'>"
    ]
   },
   {
@@ -71,8 +73,7 @@
    },
    "outputs": [],
    "source": [
-    "%%html\n",
-    "<urth-viz-explorer multi-select id='e1' ref='aDataFrame1'></urth-viz-explorer>"
+    "explore(\"aDataFrame1\")"
    ]
   },
   {
@@ -84,10 +85,22 @@
    "outputs": [],
    "source": [
     "%%html\n",
-    "<urth-viz-explorer multi-select id='e2'>\n",
+    "<urth-viz-vega-explorer multi-select id='e1' ref='aDataFrame1'></urth-viz-vega-explorer>"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "%%html\n",
+    "<urth-viz-vega-explorer multi-select id='e2'>\n",
     "  <urth-core-dataframe ref=\"aDataFrame1\" auto>\n",
     "  </urth-core-dataframe>\n",
-    "</urth-viz-explorer>"
+    "</urth-viz-vega-explorer>"
    ]
   }
  ],

--- a/kernel-python/declarativewidgets/widget_visualizations.py
+++ b/kernel-python/declarativewidgets/widget_visualizations.py
@@ -1,0 +1,10 @@
+# Copyright (c) Jupyter Development Team.
+# Distributed under the terms of the Modified BSD License.
+
+from IPython.core.display import display, HTML
+
+def explore(df):
+    """Renders the urth-viz-explorer widget to the user output"""
+    display(HTML("<link rel='import' href='urth_components/urth-viz-vega/urth-viz-vega-explorer.html' \
+                    is='urth-core-import' package='ibm-et/urth-viz-vega'> \
+                    <urth-viz-vega-explorer multi-select ref='{}'></urth-viz-vega-explorer>".format(df)))

--- a/kernel-r/declarativewidgets/DESCRIPTION
+++ b/kernel-r/declarativewidgets/DESCRIPTION
@@ -26,6 +26,7 @@ Collate:
     'widget_function.r'
     'widget_channels.r'
     'widget_dataframe.r'
+    'widget_visualizations.r'
     'serializer.r'
     'serializers.r'
     'querier.r'

--- a/kernel-r/declarativewidgets/NAMESPACE
+++ b/kernel-r/declarativewidgets/NAMESPACE
@@ -1,6 +1,7 @@
 export(initWidgets)
 export(Serializer)
 export(channel)
+export(explore)
 import(IRdisplay)
 import(IRkernel)
 import(uuid)

--- a/kernel-r/declarativewidgets/R/widget_visualizations.r
+++ b/kernel-r/declarativewidgets/R/widget_visualizations.r
@@ -1,0 +1,7 @@
+#Widget Visualization one line displays
+
+explore <- function(df) {
+    IRdisplay::display_html(paste("<link rel='import' href='urth_components/urth-viz-vega/urth-viz-vega-explorer.html'
+                                    is='urth-core-import' package='ibm-et/urth-viz-vega'>
+                                    <urth-viz-vega-explorer multi-select ref='", df, "'></urth-viz-vega-explorer>", sep = ""))
+}

--- a/kernel-scala/src/main/scala/declarativewidgets/WidgetVisualizations.scala
+++ b/kernel-scala/src/main/scala/declarativewidgets/WidgetVisualizations.scala
@@ -1,0 +1,25 @@
+/**
+  * Copyright (c) Jupyter Development Team.
+  * Distributed under the terms of the Modified BSD License.
+  */
+
+package declarativewidgets
+
+/**
+  * Object that contains Widget Visualization one line displays
+  */
+object WidgetVisualizations {
+  /**
+    * Renders the urth-viz-explorer widget to the user output
+    *
+    * @param df Dataframe variable name to render/explore
+    */
+  def explore(df: String) = {
+    val explorerImport =
+      """
+        <link rel='import' href='urth_components/urth-viz-vega/urth-viz-vega-explorer.html'
+          is='urth-core-import' package='ibm-et/urth-viz-vega'>
+      """
+    getKernel.display.html(s"$explorerImport <urth-viz-vega-explorer multi-select ref='$df'></urth-viz-vega-explorer>")
+  }
+}


### PR DESCRIPTION
Fixes https://github.com/ibm-et/urth-viz-vega/issues/3:
- Wraps the `urth-viz-explorer` widget so as to be callable from the native kernel language.  
- Example invocation in the notebook cell is `explore("aDataFrame")`.
- The explore funciton uses the `kernel.display.html` method on the kernel
