### PR TITLE
Fix collection serialization pattern matching

### DIFF
--- a/kernel-scala/src/main/scala/declarativewidgets/util/SerializationSupport.scala
+++ b/kernel-scala/src/main/scala/declarativewidgets/util/SerializationSupport.scala
@@ -36,8 +36,8 @@ trait SerializationSupport extends LogLike {
       case x: Int        => JsNumber(x)
       case x: Boolean    => JsBoolean(x)
       case x: BigDecimal => JsNumber(x)
-      case s: Seq[Any]   => JsArray((s map(serialize(_, limit))))
-      case a: Array[Any] => JsArray((a map(serialize(_, limit))))
+      case s: Seq[_]   => JsArray((s map(serialize(_, limit))))
+      case a: Array[_] => JsArray((a map(serialize(_, limit))))
       case t: Product    => JsArray((t.productIterator.toList map(serialize(_, limit))))
       case m: Map[_, _]  => JsObject(
         m.map(p => (p._1.toString, serialize(p._2, limit))).toSeq

--- a/kernel-scala/src/test/scala/declarativewidgets/util/SerializationSupportSpec.scala
+++ b/kernel-scala/src/test/scala/declarativewidgets/util/SerializationSupportSpec.scala
@@ -51,31 +51,43 @@ class SerializationSupportSpec extends FunSpec with Matchers with MockitoSugar  
 
       it("should serialize a sequence as a JsArray") {
         val d = Seq(3, "a", 4.1)
+        val dNonObjElements = Seq(3, 3)
 
         val support = spy(new TestSupport)
 
         support.serialize(d) should be(
           JsArray(Seq(JsNumber(3), JsString("a"), JsNumber(4.1)))
+        )
+        support.serialize(dNonObjElements) should be(
+          JsArray(Seq(JsNumber(3), JsNumber(3)))
         )
       }
 
       it("should serialize a array as a JsArray") {
         val d = Array(3, "a", 4.1)
+        val dNonObjElements = Array(3, 3)
 
         val support = spy(new TestSupport)
 
         support.serialize(d) should be(
           JsArray(Seq(JsNumber(3), JsString("a"), JsNumber(4.1)))
         )
+        support.serialize(dNonObjElements) should be(
+          JsArray(Seq(JsNumber(3), JsNumber(3)))
+        )
       }
 
       it("should serialize a list as a JsArray") {
         val d = List(3, "a", 4.1)
+        val dNonObjElements = List(3, 3)
 
         val support = spy(new TestSupport)
 
         support.serialize(d) should be(
           JsArray(Seq(JsNumber(3), JsString("a"), JsNumber(4.1)))
+        )
+        support.serialize(dNonObjElements) should be(
+          JsArray(Seq(JsNumber(3), JsNumber(3)))
         )
       }
 


### PR DESCRIPTION
Fixes https://github.com/jupyter-incubator/declarativewidgets/issues/449:
- The issue had to deal with [type erasure](http://stackoverflow.com/questions/1094173/how-do-i-get-around-type-erasure-on-scala-or-why-cant-i-get-the-type-paramete).  You are not able to verify the type parameter in a collection.
- For some reason it was working when it was an `Array[java.lang.Object]` which is what was in our tests, but with `Array[int]` it couldn't pattern match it and printed _.toString the object.toString.  _ will disregard the type rather than checking if it's Any.
