### PR TITLE
Explore function can take in actual df or string of df variable

### DIFF
--- a/etc/notebooks/examples/urth-core-dataframe.ipynb
+++ b/etc/notebooks/examples/urth-core-dataframe.ipynb
@@ -440,7 +440,40 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "### Example 6 - Debugging DataFrames\n",
+    "### Example 6 - Exploring DataFrames\n",
+    "explore - Enables visual exploration of different types of DataFrames.  For more information see [declarativewidgets_explorer](https://github.com/jupyter-incubator/declarativewidgets_explorer).\n",
+    "   "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "%%html\n",
+    "<urth-core-channel name=\"a\" debug><urth-core-channel>"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "from declarativewidgets.widget_visualizations import explore\n",
+    "explore(aDataFrame1, channel='a', selection_var=\"the_selected_variable\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Example 7 - Debugging DataFrames\n",
     "Sometimes, you just need a quick way to debug a DataFrame to see what it contains. Use the `debug` property to have the element display a simple table. This is particularly useful when query support show in [urth-core-query.ipynb](urth-core-query.ipynb)."
    ]
   },

--- a/etc/notebooks/examples/urth-r-widgets.ipynb
+++ b/etc/notebooks/examples/urth-r-widgets.ipynb
@@ -274,7 +274,7 @@
    },
    "outputs": [],
    "source": [
-    "explore(\"aDataFrame\", channel='a', selection_var=\"the_selected_variable\")"
+    "explore(aDataFrame, channel='a', selection_var=\"the_selected_variable\")"
    ]
   },
   {

--- a/etc/notebooks/examples/urth-scala-widgets.ipynb
+++ b/etc/notebooks/examples/urth-scala-widgets.ipynb
@@ -346,7 +346,17 @@
    },
    "outputs": [],
    "source": [
-    "import declarativewidgets.WidgetVisualizations.explore\n",
+    "import declarativewidgets.WidgetVisualizations.explore"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
     "explore(\"contacts\", channel=\"a\", selectionVar=\"theSelectedVariable\")"
    ]
   },

--- a/kernel-python/declarativewidgets/widget_visualizations.py
+++ b/kernel-python/declarativewidgets/widget_visualizations.py
@@ -4,6 +4,8 @@
 from IPython.core.display import display, HTML
 import pandas
 
+unique_explore_id = 0
+
 def explore(df, channel='default', selection_var=None):
     """
     Renders the urth-viz-explorer widget to the user output
@@ -16,7 +18,9 @@ def explore(df, channel='default', selection_var=None):
     selection_var   The selection variable by default not used/applied
     """
 
-    explore_df = "unique_explore_df_name"
+    global unique_explore_id
+    unique_explore_id += 1
+    explore_df = "unique_explore_df_name_" + str(unique_explore_id)
     if isinstance(df, pandas.DataFrame):
         get_ipython().user_ns[explore_df] = df
     else:

--- a/kernel-python/declarativewidgets/widget_visualizations.py
+++ b/kernel-python/declarativewidgets/widget_visualizations.py
@@ -3,6 +3,7 @@
 
 from IPython.core.display import display, HTML
 import pandas
+import pyspark
 
 unique_explore_id = 0
 
@@ -21,7 +22,7 @@ def explore(df, channel='default', selection_var=None):
     global unique_explore_id
     unique_explore_id += 1
     explore_df = "unique_explore_df_name_" + str(unique_explore_id)
-    if isinstance(df, pandas.DataFrame):
+    if isinstance(df, pandas.DataFrame) or isinstance(df, pyspark.sql.DataFrame):
         get_ipython().user_ns[explore_df] = df
     else:
         explore_df = df

--- a/kernel-python/declarativewidgets/widget_visualizations.py
+++ b/kernel-python/declarativewidgets/widget_visualizations.py
@@ -2,13 +2,32 @@
 # Distributed under the terms of the Modified BSD License.
 
 from IPython.core.display import display, HTML
+import pandas
 
 def explore(df, channel='default', selection_var=None):
-    """Renders the urth-viz-explorer widget to the user output"""
+    """
+    Renders the urth-viz-explorer widget to the user output
+    If pandas.DataFrame assign with unique name to user namespace else use what was passed in the string
+
+    Parameters
+    ----------
+    df              The dataframe itself or the string representation of the variable
+    channel         The channel to bind to defaulted to default
+    selection_var   The selection variable by default not used/applied
+    """
+
+    explore_df = "unique_explore_df_name"
+    if isinstance(df, pandas.DataFrame):
+        get_ipython().user_ns[explore_df] = df
+    else:
+        explore_df = df
+
+    selection = 'selection="{{{{{}}}}}"'.format(selection_var) if selection_var else ''
+
     display(HTML(
         """<link rel='import' href='urth_components/declarativewidgets-explorer/urth-viz-explorer.html'
                is='urth-core-import' package='jupyter-incubator/declarativewidgets_explorer'>
            <template is="urth-core-bind" channel="{channel}">
                <urth-viz-explorer ref='{ref}' {selection}></urth-viz-explorer>
-           </template>""".format(ref=df, channel=channel, selection = 'selection="{{{{{}}}}}"'.format(selection_var) if selection_var else '')
+           </template>""".format(ref=explore_df, channel=channel, selection=selection)
     ))

--- a/kernel-r/declarativewidgets/R/widget_visualizations.r
+++ b/kernel-r/declarativewidgets/R/widget_visualizations.r
@@ -1,10 +1,28 @@
-#Widget Visualization one line displays
+# Widget Visualization one line displays
 
+#' Explore function
+#'
+#' The explore function is a wrapper around urth-viz-explorer.
+#' See the jupyter-incubator/declarativewidgets_explorer project.
+#'
+#' @name explore
+#' @param df  the dataframe itself or the string representation of the variable
+#' @param channel  The channel to bind to defaulted to default
+#' @param selection_var  The selection variable by default not used/applied
 explore <- function(df, channel='default', selection_var=NULL) {
+    unique_df_name <- "the_literal_template_df_name"
+    register_explore_df <- function(df) {
+        #assigns df to global env and returns a unique name
+        assign(unique_df_name, df, envir = .GlobalEnv)
+        return (unique_df_name)
+    }
+
+    exlore_df_name <- ifelse(class(df) == "data.frame", register_explore_df(df), df)
     selection <- ifelse(is.null(selection_var), "", paste("selection={{", selection_var, "}}", sep=""))
+
     IRdisplay::display_html(paste("<link rel='import' href='urth_components/declarativewidgets-explorer/urth-viz-explorer.html'
                                     is='urth-core-import' package='jupyter-incubator/declarativewidgets_explorer'>
                                     <template is='urth-core-bind' channel='", channel, "'>
-                                        <urth-viz-explorer ref='", df, "' ", selection, "></urth-viz-explorer>",
+                                        <urth-viz-explorer ref='", exlore_df_name, "' ", selection, "></urth-viz-explorer>",
                                     "</template>", sep = ""))
 }

--- a/kernel-r/declarativewidgets/R/widget_visualizations.r
+++ b/kernel-r/declarativewidgets/R/widget_visualizations.r
@@ -1,5 +1,26 @@
 # Widget Visualization one line displays
 
+# explore_env that houses the explore_id
+explore_env <- new.env()
+#' gets a unique explore id by incrementing an id
+#'
+#' The function returns a unique id to be used for the explore global df references
+#' The explore_id is protected within the explore_env
+#'
+#' @name get_unique_explore_id
+get_unique_explore_id <- function() {
+    explore_id <- "explore_id"
+    #init if doesn't exist
+    if(!exists(explore_id, envir = explore_env)) {
+        assign(explore_id, 0, envir = explore_env)
+    }
+    #get and increment by one
+    temp_explore_id <- get(explore_id, envir  = explore_env)
+    assign(explore_id, temp_explore_id+1, envir = explore_env)
+    #return the id after it was incremented
+    return (get(explore_id, envir  = explore_env))
+}
+
 #' Explore function
 #'
 #' The explore function is a wrapper around urth-viz-explorer.
@@ -10,7 +31,7 @@
 #' @param channel  The channel to bind to defaulted to default
 #' @param selection_var  The selection variable by default not used/applied
 explore <- function(df, channel='default', selection_var=NULL) {
-    unique_df_name <- "the_literal_template_df_name"
+    unique_df_name <- paste("the_literal_template_df_name_", get_unique_explore_id(), sep = "")
     register_explore_df <- function(df) {
         #assigns df to global env and returns a unique name
         assign(unique_df_name, df, envir = .GlobalEnv)

--- a/kernel-r/declarativewidgets/R/widget_visualizations.r
+++ b/kernel-r/declarativewidgets/R/widget_visualizations.r
@@ -38,7 +38,7 @@ explore <- function(df, channel='default', selection_var=NULL) {
         return (unique_df_name)
     }
 
-    exlore_df_name <- ifelse(class(df) == "data.frame", register_explore_df(df), df)
+    exlore_df_name <- ifelse(class(df) == "data.frame" || class(df) == "DataFrame", register_explore_df(df), df)
     selection <- ifelse(is.null(selection_var), "", paste("selection={{", selection_var, "}}", sep=""))
 
     IRdisplay::display_html(paste("<link rel='import' href='urth_components/declarativewidgets-explorer/urth-viz-explorer.html'

--- a/kernel-scala/src/main/scala/declarativewidgets/WidgetVisualizations.scala
+++ b/kernel-scala/src/main/scala/declarativewidgets/WidgetVisualizations.scala
@@ -5,25 +5,79 @@
 
 package declarativewidgets
 
+import org.apache.spark.sql.DataFrame
+import org.apache.spark.repl.SparkIMain
+import scala.reflect.runtime.universe.ValDef
+
 /**
   * Object that contains Widget Visualization one line displays
   */
 object WidgetVisualizations {
+
   /**
-    * Renders the urth-viz-explorer widget to the user output
+    * Gets the currently executing request in SparkIMain used to inspect the explore request
     *
-    * @param df Dataframe variable name to render/explore
+    * @return The currently executing Request
     */
-  def explore(df: String, channel: String = "default", selectionVar: String = null) = {
-    val selection = if(selectionVar == null) "" else s"selection={{$selectionVar}}"
+  def getExecutingRequest(): Option[org.apache.spark.repl.SparkIMain#Request]= {
+    val iMain: SparkIMain = sparkIMain
+    val requests = iMain.getClass.getDeclaredMethods.filter(_.getName.contains("prevRequestList")).head.
+      invoke(iMain).asInstanceOf[List[_]].map(_.asInstanceOf[org.apache.spark.repl.SparkIMain#Request])
+    iMain.requestForReqId(requests.last.reqId+1)
+  }
+
+  /**
+    * Gets the DataFrame variable String representation passed into the currently running execute request
+    *
+    * @return The DataFrame variable as a String
+    */
+  def getDfNameFromLastExploreRequest(): String = {
+    val executingRequest = getExecutingRequest()
+    val requestTrees = executingRequest.map(_.trees.head.asInstanceOf[reflect.runtime.universe.Tree])
+    val valDefTrees = requestTrees collect {case c: ValDef => c}
+    val exploreTrees = valDefTrees.filter({ eTree =>
+      val children = eTree.rhs.children
+      children.length > 0 && children.head.toString.equals("explore")
+    })
+    exploreTrees.last.rhs.children(1).toString
+  }
+
+  /**
+    * Display/renderer for the kernel
+    *
+    * @param df DataFrame reference as a String
+    * @param channel channel reference as a String
+    * @param selection selection reference as a String
+    */
+  def display(df: String, channel: String, selection: String) = {
     val explorerImport =
       """
         <link rel='import' href='urth_components/declarativewidgets-explorer/urth-viz-explorer.html'
           is='urth-core-import' package='jupyter-incubator/declarativewidgets_explorer'>
       """
     getKernel.display.html(s"$explorerImport " +
-                           s"<template is='urth-core-bind' channel='$channel'>" +
+                            s"<template is='urth-core-bind' channel='$channel'>" +
                               s"<urth-viz-explorer ref='$df' $selection></urth-viz-explorer>" +
                             "</template>")
+  }
+
+  /**
+    * Renders the urth-viz-explorer widget to the user output
+    *
+    * @param df The (Spark DataFrame or String of the variable)
+    * @param channel The channel to bind to defaulted to default
+    * @param selectionVar The selection variable by default not used/applied
+    */
+  def explore(df: Any, channel: String = "default", selectionVar: String = null) = {
+    val selection = if(selectionVar == null) "" else s"selection={{$selectionVar}}"
+    df match {
+      case d : DataFrame => {
+        val dfString = getDfNameFromLastExploreRequest()
+        display(dfString, channel, selection)
+      }
+      case s: String => {
+        display(s, channel, selection)
+      }
+    }
   }
 }


### PR DESCRIPTION
Fixes https://github.com/jupyter-incubator/declarativewidgets/issues/464:
- Call with `explore(actualDf)` or `explore("actualDf")`
  - R - pure assignment to global env
  - Scala - Makes use of getting the currently executing request and extracting the first parameter of the explore function as a String.
  - Python - If pandas.DataFrame assign with unique name to user namespace else use what was passed in the string
