### PR TITLE
Fix environment variable access on pull requests from forks as a result of add jar to release

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,7 +22,7 @@ addons:
   hosts:
     - declarativewidgets.org
 
-before_install:
+before_deploy:
   openssl aes-256-cbc -K $encrypted_9067f25a9380_key -iv $encrypted_9067f25a9380_iv -in etc/.gpg/secring.gpg.enc -out etc/.gpg/secring.gpg -d
 
 before_script:


### PR DESCRIPTION
The issue arises from PR's coming from forked repos.  [before_install](https://github.com/jupyter-incubator/declarativewidgets/blob/master/.travis.yml#L26) we decrypt the secret file using environment variables.  For security reasons those environment variables are not available for PR's coming from forked repos.  For a more complete explanation see [Pull-Requests-and-Security-Restrictions](https://docs.travis-ci.com/user/pull-requests#Pull-Requests-and-Security-Restrictions) and [Convenience-Variables](https://docs.travis-ci.com/user/environment-variables/#Convenience-Variables)
