### PR TITLE
Added the ability to call/reference functions within objects in Scala/R [See PR #436 first]

### DIFF
--- a/etc/docs/site/usage-docs/Calling-Functions.md
+++ b/etc/docs/site/usage-docs/Calling-Functions.md
@@ -19,7 +19,20 @@ def someFunction(a,b,c):
 
 ```html
 %%HTML
-<urth-core-function arg-a="..." arg-b="..." arg-c="..." result="..."></urth-core-function>
+<urth-core-function ref='t' arg-a="..." arg-b="..." arg-c="..." result="..."></urth-core-function>
+```
+
+Note function references are not limited to notebook level variable declarations, but can also be in reference to functions within objects.
+For example, given the following `Test` class:
+```Python
+class Test:
+    def math(self, x, y):
+        return x*y
+t = Test()
+```
+We can then reference it as
+```html
+<urth-core-function ref='t.math' ...></urth-core-function>
 ```
 
 #### Connecting the element to the function

--- a/etc/notebooks/examples/urth-r-widgets.ipynb
+++ b/etc/notebooks/examples/urth-r-widgets.ipynb
@@ -101,6 +101,51 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
+    "#### Calling a function within an object"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "library(R6)\n",
+    "Test <- R6Class(\n",
+    "    'Test',\n",
+    "    public = list(\n",
+    "        moreMath = function(x, y) {\n",
+    "            return (x*y)\n",
+    "        }\n",
+    "    )\n",
+    ")\n",
+    "t <- Test$new()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "IRdisplay::display_html(\"\n",
+    "<template is='dom-bind'>\n",
+    "<urth-core-function ref='t$moreMath' arg-x='{{x}}' arg-y='{{y}}' result='{{res}}' auto></urth-core-function>\n",
+    "    <label>x:</label><paper-slider min='10' max='100' step='1' value='{{x}}'></paper-slider><span>{{x}}</span><br>\n",
+    "    <label>y:</label><paper-slider min='1' max='100' step='1' value='{{y}}'></paper-slider><span>{{y}}</span><br>\n",
+    "Result: <span>{{res}}</span>\n",
+    "</template>\n",
+    "\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
     "### Channels"
    ]
   },

--- a/etc/notebooks/examples/urth-scala-widgets.ipynb
+++ b/etc/notebooks/examples/urth-scala-widgets.ipynb
@@ -115,6 +115,44 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
+    "#### Def within an Object"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": [
+    "class Test() {\n",
+    "    def moreMath(x: Int, y: Double = 50): Double = x * y\n",
+    "}\n",
+    "val t = new Test()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "%%html\n",
+    "<template is=\"dom-bind\">\n",
+    "<urth-core-function ref=\"t.moreMath\" arg-x=\"{{x}}\" arg-y=\"{{y}}\" result=\"{{res}}\" auto></urth-core-function>\n",
+    "    <label>x:</label><paper-slider min=\"10\" max=\"100\" step=\"1\" value=\"{{x}}\"></paper-slider><span>{{x}}</span><br>\n",
+    "    <label>y:</label><paper-slider min=\"1\" max=\"100\" step=\"1\" value=\"{{y}}\"></paper-slider><span>{{y}}</span><br>\n",
+    "Result: <span>{{res}}</span>\n",
+    "</template>"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
     "#### Val"
    ]
   },

--- a/etc/notebooks/tests/Walkthrough.ipynb
+++ b/etc/notebooks/tests/Walkthrough.ipynb
@@ -162,6 +162,59 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
+    "Reference/invoke a function within an object"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "class Test:\n",
+    "    def greet_again(self, name=\"world\"):\n",
+    "        return \"Hello {0}!\".format(name)\n",
+    "test = Test()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "%%html\n",
+    "<template is=\"urth-core-bind\">\n",
+    "    <urth-core-function id=\"fWithinObj\" ref=\"test.greet_again\" arg-name=\"{{name}}\" result=\"{{greeting}}\" is-ready=\"{{isready}}\"></urth-core-function>\n",
+    "    <label>Name:</label> <input type=\"text\" value=\"{{name::change}}\"></input><br/>\n",
+    "</template> "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "%%html\n",
+    "<template is=\"urth-core-bind\">\n",
+    "    <template is=\"dom-if\" if=\"[[isready]]\">\n",
+    "        <button id=\"invokeButtonWithinObj\" onClick=\"fWithinObj.invoke()\">invoke</button><br/>\n",
+    "        <span id=\"testWithinObj\">{{greeting}}</span>\n",
+    "    </template>\n",
+    "</template> "
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
     "Click [here](../examples/urth-core-function.ipynb) to learn more about `<urth-core-function>`"
    ]
   },

--- a/kernel-python/declarativewidgets/util/functions_py2.py
+++ b/kernel-python/declarativewidgets/util/functions_py2.py
@@ -5,8 +5,14 @@
 
 import inspect
 
-def parameter_types(func):
+def get_arg_spec(func):
     sig = inspect.getargspec(func)
+    if "self" in sig.args:
+        sig.args.remove("self")
+    return sig
+
+def parameter_types(func):
+    sig = get_arg_spec(func)
     required = required_parameter(func)
     default = default_parameters(func)
 
@@ -21,7 +27,7 @@ def parameter_types(func):
 
 
 def default_parameters(func):
-    sig = inspect.getargspec(func)
+    sig = get_arg_spec(func)
 
     if sig.defaults:
         return dict(zip(sig.args[-len(sig.defaults):], sig.defaults))
@@ -30,7 +36,7 @@ def default_parameters(func):
 
 
 def required_parameter(func):
-    sig = inspect.getargspec(func)
+    sig = get_arg_spec(func)
 
     if sig.defaults:
         return list(set(sig.args) - set(sig.args[-len(sig.defaults):]))

--- a/kernel-r/declarativewidgets/R/widget_function.r
+++ b/kernel-r/declarativewidgets/R/widget_function.r
@@ -61,9 +61,18 @@ Widget_Function <- R6Class(
             response <- self$send_signature(func_name, self$limit)
             self$handle_function_response(response)
         },
+        get_global_function = function(func_name) {
+            func_name_parts <- unlist(strsplit(func_name, "$", fixed = TRUE))
+            if(length(func_name_parts > 1)) {
+                klass <- get(func_name_parts[1], envir = .GlobalEnv)
+                return (klass[[(func_name_parts[2])]])
+            } else {
+                return (get(func_name_parts[1], envir = .GlobalEnv))
+            }
+        },
         invoke_function = function(func_name, args, limit=self$limit) {
             #get function from user/global env
-            func <- get(func_name, envir = .GlobalEnv)
+            func <- self$get_global_function(func_name)
             #resolve args from defined env with args from client
             converted_args <- self$convert_args(func, args)
             #call the function with the list of args (convert_args is a list of values in order)
@@ -122,7 +131,7 @@ Widget_Function <- R6Class(
         get_signature = function(func_name) {
             names <- list()
             tryCatch({
-                func <- get(func_name, envir = .GlobalEnv)
+                func <- self$get_global_function(func_name)
                 func_param_list <- formals(func)
                 for(param in names(func_param_list)) {
                     names[[param]] <- list()

--- a/kernel-r/declarativewidgets/R/widget_function.r
+++ b/kernel-r/declarativewidgets/R/widget_function.r
@@ -63,7 +63,7 @@ Widget_Function <- R6Class(
         },
         get_global_function = function(func_name) {
             func_name_parts <- unlist(strsplit(func_name, "$", fixed = TRUE))
-            if(length(func_name_parts > 1)) {
+            if(length(func_name_parts) > 1) {
                 klass <- get(func_name_parts[1], envir = .GlobalEnv)
                 return (klass[[(func_name_parts[2])]])
             } else {

--- a/system-test/urth-system-test-specs.js
+++ b/system-test/urth-system-test-specs.js
@@ -14,12 +14,22 @@ describe('Widgets System Test', function() {
             .text().should.eventually.include('Luke')
             .nodeify(done);
     });
+
     it('should print the correct variable that is used for urth-core-function', function(done) {
         boilerplate.browser
             .waitForElementById('invokeButton', wd.asserters.isDisplayed, 10000)
             .click()
             .click() // Safari requires extra click for some reason
             .waitForElementById('test1', wd.asserters.textInclude('world'), 10000)
+            .nodeify(done);
+    });
+
+    it('should print the correct variable that is used for urth-core-function that is within an object', function(done) {
+        boilerplate.browser
+            .waitForElementById('invokeButtonWithinObj', wd.asserters.isDisplayed, 10000)
+            .click()
+            .click() // Safari requires extra click for some reason
+            .waitForElementById('testWithinObj', wd.asserters.textInclude('world'), 10000)
             .nodeify(done);
     });
 


### PR DESCRIPTION
- Follow on to the Python PR https://github.com/jupyter-incubator/declarativewidgets/pull/436.  This adds the ability to call functions within objects in Scala/R as well.  
- Examples have been added to the R and Scala notebooks.
- usage-docs/Calling-Functions.md have been updated
- Usage Example
  - `val t = new Test()` defined can then have the ref of the function be `ref='t.math'` where math is a function of the instance `t`.
