### PR TITLE
Fix R system tests on safari by clicking button twice

### DIFF
--- a/system-test/urth-r-widgets-specs.js
+++ b/system-test/urth-r-widgets-specs.js
@@ -16,7 +16,9 @@ process.env.PYTHON != "python2" && describe('Widgets R System Test', function() 
 
     it('should bind and update a channel variable', function(done) {
         boilerplate.browser
-            .waitForElementById('invokeButton').click()
+            .waitForElementById('invokeButton', wd.asserters.isDisplayed, 60000)
+            .click()
+            .click() // Safari requires extra click for some reason
             .waitForElementByClassName('test2', wd.asserters.textInclude('mike'), 60000)
             .nodeify(done);
     });


### PR DESCRIPTION
Follow on to #407 and #505.

I saw this used in the [python version](https://github.com/jupyter-incubator/declarativewidgets/blob/master/system-test/urth-system-test-specs.js#L22).  It may be worth merging if we see issues.
