### PR TITLE
Enable DataFrame reference within objects in Python

### DIFF
--- a/kernel-python/declarativewidgets/widget_dataframe.py
+++ b/kernel-python/declarativewidgets/widget_dataframe.py
@@ -37,10 +37,11 @@ class DataFrame(UrthWidget):
         self.log.info("Changed value of query to {}...".format(new))
 
     def _the_dataframe(self):
-        if self.variable_name in self.shell.user_ns:
-            return self.shell.user_ns[self.variable_name]
-        else:
-            raise UrthException("Invalid DataFrame variable name {}".format(
+        try:
+            name = self.variable_name.split('.')
+            return reduce(lambda x, y: getattr(x, y), [self.shell.user_ns[name.pop(0)]] + name)
+        except (KeyError, AttributeError):
+            raise UrthException("Invalid DataFrame name {}".format(
                 self.variable_name))
 
     def _handle_state_msg(self, wid, content, buffers):

--- a/kernel-python/declarativewidgets/widget_dataframe.py
+++ b/kernel-python/declarativewidgets/widget_dataframe.py
@@ -10,6 +10,8 @@ from .urth_widget import UrthWidget
 from .urth_exception import UrthException
 import json
 
+from functools import reduce
+
 
 class DataFrame(UrthWidget):
     """


### PR DESCRIPTION
before: DataFrame variables can just be global variables.
after: DataFrame can be a member of a class instance, like functions.