### PR TITLE
Remove requirement of SparkR

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -64,6 +64,9 @@ bower_components
 *.log
 node_modules/
 npm-debug.*
+*.Rproj
+.Rproj.user
+.Rhistory
 .watch
 .watch-docs
 project/

--- a/kernel-r/declarativewidgets/.Rbuildignore
+++ b/kernel-r/declarativewidgets/.Rbuildignore
@@ -1,0 +1,2 @@
+^.*\.Rproj$
+^\.Rproj\.user$

--- a/kernel-r/declarativewidgets/DESCRIPTION
+++ b/kernel-r/declarativewidgets/DESCRIPTION
@@ -19,8 +19,7 @@ Imports:
     IRdisplay,
     uuid,
     jsonlite,
-    R6,
-    SparkR
+    R6
 Collate:
     'widget.r'
     'widget_function.r'

--- a/kernel-r/declarativewidgets/R/serializer.r
+++ b/kernel-r/declarativewidgets/R/serializer.r
@@ -21,8 +21,10 @@ Serializer <- R6Class(
         },
         load_serializers = function() {
             self$register_serializer(DataFrame_Serializer$new())
-            self$register_serializer(Spark_DataFrame_Serializer$new())
             self$register_serializer(Time_Series_Serializer$new())
+            if ("SparkR" %in% rownames(installed.packages())) {
+              self$register_serializer(Spark_DataFrame_Serializer$new())
+            }
         },
         initialize = function() {
             self$load_serializers()

--- a/kernel-r/declarativewidgets/R/serializer.r
+++ b/kernel-r/declarativewidgets/R/serializer.r
@@ -17,14 +17,16 @@ Serializer <- R6Class(
             return (obj)
         },
         register_serializer = function(a_serializer) {
-            self$serializer_list[[a_serializer$klass()]] <- a_serializer$serialize
+            if (a_serializer$check_packages()) {
+                self$serializer_list[[a_serializer$klass()]] <- a_serializer$serialize
+            } else {
+                log_info(paste("Unable to load", class(a_serializer)[1], ": dependent package not found."))
+            }
         },
         load_serializers = function() {
             self$register_serializer(DataFrame_Serializer$new())
             self$register_serializer(Time_Series_Serializer$new())
-            if ("SparkR" %in% rownames(installed.packages())) {
-              self$register_serializer(Spark_DataFrame_Serializer$new())
-            }
+            self$register_serializer(Spark_DataFrame_Serializer$new())
         },
         initialize = function() {
             self$load_serializers()

--- a/kernel-r/declarativewidgets/R/serializers.r
+++ b/kernel-r/declarativewidgets/R/serializers.r
@@ -67,10 +67,10 @@ DataFrame_Serializer <- R6Class(
         check_packages = function() {
             tryCatch({
                 library(base)
+                return (TRUE)
             }, error = function(e) {
-                return (False)
             })
-            return (True)
+            return (FALSE)
         },
         initialize = function() {
             #initialize must exists on this class
@@ -109,10 +109,10 @@ Spark_DataFrame_Serializer <- R6Class(
         check_packages = function() {
             tryCatch({
                 library(SparkR)
+                return (TRUE)
             }, error = function(e) {
-                return (False)
             })
-            return (True)
+            return (FALSE)
         },
         initialize = function() {
             #initialize must exists on this class
@@ -146,10 +146,10 @@ Time_Series_Serializer <- R6Class(
         check_packages = function() {
             tryCatch({
                 library(base)
+                return (TRUE)
             }, error = function(e) {
-                return (False)
             })
-            return (True)
+            return (FALSE)
         },
         initialize = function() {
             #initialize must exists on this class

--- a/kernel-r/declarativewidgets/tests/testthat/test_df_queries.R
+++ b/kernel-r/declarativewidgets/tests/testthat/test_df_queries.R
@@ -7,11 +7,16 @@ letters <- c('A', 'B', 'C', 'C', 'C', 'D')
 numbers <- c(1, 2, 3, 4, 5, 6)
 df <- data.frame(letters, numbers)
 df$letters <- as.character(df$letters)
+
 #common spark_df
-library(SparkR)
-sc <- sparkR.init()
-sqlContext <- sparkRSQL.init(sc)
-spark_df <- createDataFrame(sqlContext, df)
+if (require(SparkR, quietly=TRUE)) {
+    library(SparkR)
+    sc <- sparkR.init()
+    sqlContext <- sparkRSQL.init(sc)
+    spark_df <- createDataFrame(sqlContext, df)
+} else {
+    message("The package SparkR is not installed. Tests will be skipped.")
+}
 
 test_that("apply_query_single_filter", {
     #note the filter equality difference on those query strings
@@ -19,19 +24,23 @@ test_that("apply_query_single_filter", {
     new_df <- querier$apply_query(df, fromJSON(single_filter_query_df))
     expect_equal(nrow(new_df), 3)
 
-    single_filter_query_spark_df <- "[{\"type\":\"filter\",\"expr\":\"letters = 'C'\"}]"
-    new_spark_df <- querier$apply_query(spark_df, fromJSON(single_filter_query_spark_df))
-    expect_equal(nrow(collect(new_spark_df)), 3)
+    if (exists("spark_df")) {
+        single_filter_query_spark_df <- "[{\"type\":\"filter\",\"expr\":\"letters = 'C'\"}]"
+        new_spark_df <- querier$apply_query(spark_df, fromJSON(single_filter_query_spark_df))
+        expect_equal(nrow(collect(new_spark_df)), 3)
+    }
 })
 
 test_that("apply_query_multiple_filters", {
     multiple_filter_query_df <- "[{\"type\":\"filter\",\"expr\":\"letters == 'C'\"}, {\"type\":\"filter\",\"expr\":\"numbers == '4'\"}]"
     new_df <- querier$apply_query(df, fromJSON(multiple_filter_query_df))
     expect_equal(nrow(new_df), 1)
-
-    multiple_filter_query_spark_df <- "[{\"type\":\"filter\",\"expr\":\"letters = 'C'\"}, {\"type\":\"filter\",\"expr\":\"numbers = '4'\"}]"
-    new_spark_df <- querier$apply_query(spark_df, fromJSON(multiple_filter_query_spark_df))
-    expect_equal(nrow(collect(new_spark_df)), 1)
+    
+    if (exists("spark_df")) {
+        multiple_filter_query_spark_df <- "[{\"type\":\"filter\",\"expr\":\"letters = 'C'\"}, {\"type\":\"filter\",\"expr\":\"numbers = '4'\"}]"
+        new_spark_df <- querier$apply_query(spark_df, fromJSON(multiple_filter_query_spark_df))
+        expect_equal(nrow(collect(new_spark_df)), 1)
+    }
 })
 
 test_that("apply_query_sort_ascending_false", {
@@ -40,9 +49,11 @@ test_that("apply_query_sort_ascending_false", {
 
     new_df <- querier$apply_query(df, query)
     expect_equal(as.numeric(new_df$numbers[1]), 6)
-
-    new_spark_df <- querier$apply_query(spark_df, query)
-    expect_equal(as.numeric(collect(new_spark_df)$numbers[1]), 6)
+    
+    if (exists("spark_df")) {
+        new_spark_df <- querier$apply_query(spark_df, query)
+        expect_equal(as.numeric(collect(new_spark_df)$numbers[1]), 6)
+    }
 })
 
 test_that("apply_query_sort_ascending_true", {
@@ -51,19 +62,23 @@ test_that("apply_query_sort_ascending_true", {
 
     new_df <- querier$apply_query(df, query)
     expect_equal(as.numeric(new_df$numbers[1]), 1)
-
-    new_spark_df <- querier$apply_query(spark_df, query)
-    expect_equal(as.numeric(collect(new_spark_df)$numbers[1]), 1)
+    
+    if (exists("spark_df")) {
+        new_spark_df <- querier$apply_query(spark_df, query)
+        expect_equal(as.numeric(collect(new_spark_df)$numbers[1]), 1)
+    }
 })
 
 test_that("apply_query_sort_and_filter", {
     sort_and_filter_query_df <- "[{\"type\":\"filter\",\"expr\":\"letters == 'C'\"}, {\"type\":\"sort\",\"expr\":{\"by\":\"numbers\",\"ascending\":false}}]"
     new_df <- querier$apply_query(df, fromJSON(sort_and_filter_query_df))
     expect_equal(as.numeric(new_df$numbers[1]), 5)
-
-    sort_and_filter_query_spark_df <- "[{\"type\":\"filter\",\"expr\":\"letters = 'C'\"}, {\"type\":\"sort\",\"expr\":{\"by\":\"numbers\",\"ascending\":false}}]"
-    new_spark_df <- querier$apply_query(spark_df, fromJSON(sort_and_filter_query_spark_df))
-    expect_equal(as.numeric(collect(new_spark_df)$numbers[1]), 5)
+    
+    if (exists("spark_df")) {
+        sort_and_filter_query_spark_df <- "[{\"type\":\"filter\",\"expr\":\"letters = 'C'\"}, {\"type\":\"sort\",\"expr\":{\"by\":\"numbers\",\"ascending\":false}}]"
+        new_spark_df <- querier$apply_query(spark_df, fromJSON(sort_and_filter_query_spark_df))
+        expect_equal(as.numeric(collect(new_spark_df)$numbers[1]), 5)
+    }
 })
 
 test_that("apply_query_groupby", {
@@ -74,11 +89,13 @@ test_that("apply_query_groupby", {
     expect_equal(nrow(new_df), 4)
     expect_equal(as.numeric(new_df$sum_numbers[3]), 12)
     expect_equal(as.numeric(new_df$mean_numbers[3]), 4)
-
-    new_spark_df <- querier$apply_query(spark_df, query)
-    expect_equal(nrow(collect(new_spark_df)), 4)
-    expect_equal(as.numeric(collect(new_spark_df)$sum_numbers[3]), 12)
-    expect_equal(as.numeric(collect(new_spark_df)$mean_numbers[3]), 4)
+    
+    if (exists("spark_df")) {
+        new_spark_df <- querier$apply_query(spark_df, query)
+        expect_equal(nrow(collect(new_spark_df)), 4)
+        expect_equal(as.numeric(collect(new_spark_df)$sum_numbers[3]), 12)
+        expect_equal(as.numeric(collect(new_spark_df)$mean_numbers[3]), 4)
+    }
 })
 
 test_that("apply_query_groupby_and_filter", {
@@ -87,10 +104,12 @@ test_that("apply_query_groupby_and_filter", {
     expect_equal(nrow(new_df), 1)
     expect_equal(as.numeric(new_df$sum_numbers[1]), 12)
     expect_equal(as.numeric(new_df$mean_numbers[1]), 4)
-
-    groupby_and_filter_query_spark_df <- "[{\"type\":\"filter\",\"expr\":\"letters = 'C'\"}, {\"type\":\"group\",\"expr\":{\"by\":[\"letters\"],\"agg\":[{\"op\":\"sum\",\"col\":\"numbers\"},{\"op\":\"mean\",\"col\":\"numbers\"}]}}]"
-    new_spark_df <- querier$apply_query(spark_df, fromJSON(groupby_and_filter_query_spark_df))
-    expect_equal(nrow(collect(new_spark_df)), 1)
-    expect_equal(as.numeric(collect(new_spark_df)$sum_numbers[1]), 12)
-    expect_equal(as.numeric(collect(new_spark_df)$mean_numbers[1]), 4)
+    
+    if (exists("spark_df")) {
+        groupby_and_filter_query_spark_df <- "[{\"type\":\"filter\",\"expr\":\"letters = 'C'\"}, {\"type\":\"group\",\"expr\":{\"by\":[\"letters\"],\"agg\":[{\"op\":\"sum\",\"col\":\"numbers\"},{\"op\":\"mean\",\"col\":\"numbers\"}]}}]"
+        new_spark_df <- querier$apply_query(spark_df, fromJSON(groupby_and_filter_query_spark_df))
+        expect_equal(nrow(collect(new_spark_df)), 1)
+        expect_equal(as.numeric(collect(new_spark_df)$sum_numbers[1]), 12)
+        expect_equal(as.numeric(collect(new_spark_df)$mean_numbers[1]), 4)
+    }
 })


### PR DESCRIPTION
As R users are not always using SparkR, it is better to activate the Spark DataFrame serializer only when SparkR is installed.

BTW, check_packages() in declarativewidgets/kernel-r/declarativewidgets/R/serializers.r always returns TRUE. It is also fixed in this PR.