### PR TITLE
Improve urth-core-behaviors/error-display-behavior

### DIFF
--- a/elements/urth-core-behaviors/error-display-behavior.html
+++ b/elements/urth-core-behaviors/error-display-behavior.html
@@ -42,7 +42,7 @@ This behavior is used to encapsulate some of the services needed for urth elemen
                     var errorNode = document.createElement("pre")
                     errorNode.innerHTML = msg;
                     errorNode.classList.add("urth-widget-error");
-                    Polymer.dom(this.root).appendChild(errorNode);
+                    Polymer.dom(this.root).parentNode.appendChild(errorNode);
                 }
                 var widgetName = this.nodeName.toLowerCase();
                 console.error(widgetName + ": " + msg);

--- a/elements/urth-core-behaviors/error-display-behavior.html
+++ b/elements/urth-core-behaviors/error-display-behavior.html
@@ -40,12 +40,12 @@ This behavior is used to encapsulate some of the services needed for urth elemen
             displayErrorMessage: function(msg){
                 var widgetName = this.nodeName.toLowerCase();
 				if (!window.Urth.suppressErrors) {
-                    var errorNode = document.createElement("pre")
+                    var errorNode = document.createElement("pre");
                     errorNode.innerHTML = msg;
                     errorNode.classList.add("urth-widget-error");
 					var appendNode = Polymer.dom(this.root);
 					// if widgetName in a given set, append error message in parent node.
-					if({'urth-core-function': true}[widgetName])
+                    if({'urth-core-function': true}[widgetName])
 						appendNode = appendNode.parentNode;
                     appendNode.appendChild(errorNode);
                 }

--- a/elements/urth-core-behaviors/error-display-behavior.html
+++ b/elements/urth-core-behaviors/error-display-behavior.html
@@ -40,12 +40,12 @@ This behavior is used to encapsulate some of the services needed for urth elemen
             displayErrorMessage: function(msg){
                 var widgetName = this.nodeName.toLowerCase();
 				if (!window.Urth.suppressErrors) {
-                    var errorNode = document.createElement("pre");
+                    var errorNode = document.createElement("pre")
                     errorNode.innerHTML = msg;
                     errorNode.classList.add("urth-widget-error");
 					var appendNode = Polymer.dom(this.root);
 					// if widgetName in a given set, append error message in parent node.
-                    if({'urth-core-function': true}[widgetName])
+					if({'urth-core-function': true}[widgetName])
 						appendNode = appendNode.parentNode;
                     appendNode.appendChild(errorNode);
                 }

--- a/elements/urth-core-behaviors/error-display-behavior.html
+++ b/elements/urth-core-behaviors/error-display-behavior.html
@@ -38,14 +38,18 @@ This behavior is used to encapsulate some of the services needed for urth elemen
              * @param String msg
              */
             displayErrorMessage: function(msg){
-                if (!window.Urth.suppressErrors) {
+                var widgetName = this.nodeName.toLowerCase();
+				if (!window.Urth.suppressErrors) {
                     var errorNode = document.createElement("pre")
                     errorNode.innerHTML = msg;
                     errorNode.classList.add("urth-widget-error");
-                    Polymer.dom(this.root).parentNode.appendChild(errorNode);
+					var appendNode = Polymer.dom(this.root);
+					// if widgetName in a given set, append error message in parent node.
+					if({'urth-core-function': true}[widgetName])
+						appendNode = appendNode.parentNode;
+                    appendNode.appendChild(errorNode);
                 }
-                var widgetName = this.nodeName.toLowerCase();
-                console.error(widgetName + ": " + msg);
+				console.error(widgetName + ": " + msg);
             }
         };
     })();

--- a/elements/urth-core-behaviors/error-display-behavior.html
+++ b/elements/urth-core-behaviors/error-display-behavior.html
@@ -38,18 +38,14 @@ This behavior is used to encapsulate some of the services needed for urth elemen
              * @param String msg
              */
             displayErrorMessage: function(msg){
-                var widgetName = this.nodeName.toLowerCase();
-				if (!window.Urth.suppressErrors) {
+                if (!window.Urth.suppressErrors) {
                     var errorNode = document.createElement("pre")
                     errorNode.innerHTML = msg;
                     errorNode.classList.add("urth-widget-error");
-					var appendNode = Polymer.dom(this.root);
-					// if widgetName in a given set, append error message in parent node.
-					if({'urth-core-function': true}[widgetName])
-						appendNode = appendNode.parentNode;
-                    appendNode.appendChild(errorNode);
+                    Polymer.dom(this.root).parentNode.appendChild(errorNode);
                 }
-				console.error(widgetName + ": " + msg);
+                var widgetName = this.nodeName.toLowerCase();
+                console.error(widgetName + ": " + msg);
             }
         };
     })();

--- a/elements/urth-core-behaviors/error-display-behavior.html
+++ b/elements/urth-core-behaviors/error-display-behavior.html
@@ -42,7 +42,7 @@ This behavior is used to encapsulate some of the services needed for urth elemen
                     var errorNode = document.createElement("pre")
                     errorNode.innerHTML = msg;
                     errorNode.classList.add("urth-widget-error");
-                    Polymer.dom(this.root).parentNode.appendChild(errorNode);
+                    Polymer.dom(this.root).appendChild(errorNode);
                 }
                 var widgetName = this.nodeName.toLowerCase();
                 console.error(widgetName + ": " + msg);

--- a/elements/urth-core-function/urth-core-function.html
+++ b/elements/urth-core-function/urth-core-function.html
@@ -140,8 +140,7 @@ Note that when using the 'click' event approach described above in #3, a click o
             ],
 
             listeners: {
-                'watch_notify': 'invoke',
-                'click': '_tryInvoke'
+                'watch_notify': 'invoke'
             },
 
             created: function(){
@@ -155,6 +154,13 @@ Note that when using the 'click' event approach described above in #3, a click o
                 if( !this.args ){
                     //sync with the attributes
                     this.args = this._paramsFromAttributes();
+                }
+            },
+            
+            attached: function() {
+                var toListen = Polymer.dom(this.root).querySelectorAll('*');
+                for (var i = 0; i < toListen.length; i++) {
+                    this.listen(toListen[i], 'click', '_tryInvoke');
                 }
             },
 


### PR DESCRIPTION
Before: error message append into <urth-core-functoin>
After: error message append after <urth-core-function>.

This is particularly useful when users write
`<urth-core-function><buton>invoke</button></urth-core-function>`.
Before this improvements, when users click on the error message, the
function will be invoked again (click event broadcast to error message).
After this improvement, this issue is fixed.