### PR TITLE
Simplify backend init func

### DIFF
--- a/kernel-python/declarativewidgets/__init__.py
+++ b/kernel-python/declarativewidgets/__init__.py
@@ -1,38 +1,5 @@
 # Copyright (c) Jupyter Development Team.
 # Distributed under the terms of the Modified BSD License.
-from IPython.core.display import display, Javascript
-
-def init():
-    # JavaScript code to load the declarative widgets extension.
-    # Code sent to the front end from here may be executed after
-    # extension initialization (iterative cell execution) or
-    # before (Run All, Reload). This code works together with the
-    # extension initialization to ensure that the required API is
-    # available in all scenarios.
-    #
-    # Urth._initialized is a deferred that is resolved by the extension
-    # initialization after the global Urth instance has been setup.
-    # If extension initialization has not completed a new deferred is
-    # initialized which extension initialization will resolve.
-    #
-    # Urth.whenReady is a public API defined by extension initialization
-    # to delay javascript execution until dependencies have loaded. If
-    # extension initialization has not completed a wrapper implementation
-    # is setup which will invoke the real implementation when it is available.
-    code = '''
-        window.Urth = window.Urth || {};
-        Urth._initialized = Urth._initialized || $.Deferred();
-        Urth.whenReady = Urth.whenReady || function(cb) {
-            Urth._initialized.then(function() {
-                Urth.whenReady(cb);
-            });
-        };
-        Urth.whenReady(function() { console.log("Declarative widgets connected.") });
-        '''
-
-    # Send the code to the browser.
-    display(Javascript(code))
-
 from .widget_channels import channel
 from .widget_channels import Channels
 from .widget_function import Function
@@ -40,3 +7,5 @@ from .widget_dataframe import DataFrame
 from .widget_ipw_proxy import IpywProxy
 from .util.explore import explore
 
+def init():
+    pass

--- a/kernel-r/declarativewidgets/R/widget.r
+++ b/kernel-r/declarativewidgets/R/widget.r
@@ -140,31 +140,4 @@ initWidgets <- function() {
 
     # Support for ipywidgets 5.x client
     comm_manager$register_target("jupyter.widget", target_handler)
-
-    # JavaScript code to load the declarative widgets extension.
-    # Code sent to the front end from here may be executed after
-    # extension initialization (iterative cell execution) or
-    # before (Run All, Reload). This code works together with the
-    # extension initialization to ensure that the required API is
-    # available in all scenarios.
-    #
-    # Urth._initialized is a deferred that is resolved by the extension
-    # initialization after the global Urth instance has been setup.
-    # If extension initialization has not completed a new deferred is
-    # initialized which extension initialization will resolve.
-    #
-    # Urth.whenReady is a public API defined by extension initialization
-    # to delay javascript execution until dependencies have loaded. If
-    # extension initialization has not completed a wrapper implementation
-    # is setup which will invoke the real implementation when it is available.
-    display_javascript('
-        window.Urth = window.Urth || {};
-        Urth._initialized = Urth._initialized || $.Deferred();
-        Urth.whenReady = Urth.whenReady || function(cb) {
-            Urth._initialized.then(function() {
-                Urth.whenReady(cb);
-            });
-        };
-        Urth.whenReady(function() { console.log("Declarative widgets connected.") });
-    ')
 }

--- a/kernel-scala/src/main/scala/declarativewidgets/package.scala
+++ b/kernel-scala/src/main/scala/declarativewidgets/package.scala
@@ -94,34 +94,6 @@ package object declarativewidgets {
       .addOpenHandler(Widget.openCallback)
       .addMsgHandler(Widget.msgCallback)
     _the_kernel = kernel
-
-    // JavaScript code to load the declarative widgets extension.
-    // Code sent to the front end from here may be executed after
-    // extension initialization (iterative cell execution) or
-    // before (Run All, Reload). This code works together with the
-    // extension initialization to ensure that the required API is
-    // available in all scenarios.
-    //
-    // Urth._initialized is a deferred that is resolved by the extension
-    // initialization after the global Urth instance has been setup.
-    // If extension initialization has not completed a new deferred is
-    // initialized which extension initialization will resolve.
-    //
-    // Urth.whenReady is a public API defined by extension initialization
-    // to delay javascript execution until dependencies have loaded. If
-    // extension initialization has not completed a wrapper implementation
-    // is setup which will invoke the real implementation when it is available.
-    val code = """
-      window.Urth = window.Urth || {};
-      Urth._initialized = Urth._initialized || $.Deferred();
-      Urth.whenReady = Urth.whenReady || function(cb) {
-        Urth._initialized.then(function() {
-          Urth.whenReady(cb);
-        });
-      };
-      Urth.whenReady(function() { console.log("Declarative widgets connected.") });"""
-
-    kernel.display.javascript(code)
   }
 
   def getKernel: Kernel = {

--- a/nb-extension/js/init/init.js
+++ b/nb-extension/js/init/init.js
@@ -27,7 +27,17 @@ define([
         window.console[method] = window.console[method] || window.console.log;
     });
 	
-    window.Urth = window.Urth || {};
+
+    // Urth._initialized is a deferred that is resolved by the extension		
+    // initialization after the global Urth instance has been setup.
+    // If extension initialization has not completed a new deferred is
+    // initialized which extension initialization will resolve.
+    //		
+    // Urth.whenReady is a public API defined by extension initialization
+    // to delay javascript execution until dependencies have loaded. If
+    // extension initialization has not completed a wrapper implementation
+    // is setup which will invoke the real implementation when it is available.
+	window.Urth = window.Urth || {};
     Urth._initialized = Urth._initialized || $.Deferred();
     Urth.whenReady = Urth.whenReady || function(cb) {
         Urth._initialized.then(function() {

--- a/nb-extension/js/init/init.js
+++ b/nb-extension/js/init/init.js
@@ -37,7 +37,7 @@ define([
     // to delay javascript execution until dependencies have loaded. If
     // extension initialization has not completed a wrapper implementation
     // is setup which will invoke the real implementation when it is available.
-	window.Urth = window.Urth || {};
+    window.Urth = window.Urth || {};
     Urth._initialized = Urth._initialized || $.Deferred();
     Urth.whenReady = Urth.whenReady || function(cb) {
         Urth._initialized.then(function() {

--- a/nb-extension/js/init/init.js
+++ b/nb-extension/js/init/init.js
@@ -26,6 +26,15 @@ define([
     ['debug', 'error', 'trace', 'warn'].forEach(function (method) {
         window.console[method] = window.console[method] || window.console.log;
     });
+	
+    window.Urth = window.Urth || {};
+    Urth._initialized = Urth._initialized || $.Deferred();
+    Urth.whenReady = Urth.whenReady || function(cb) {
+        Urth._initialized.then(function() {
+            Urth.whenReady(cb);
+        });
+    };
+    Urth.whenReady(function() { console.log("Declarative widgets connected.") });
 
     var COMPONENTS_DIR = 'urth_components';
 


### PR DESCRIPTION
The JS code in Py/R/Scala init() function seems to be same, can we move these JS code to the `nb-extension/init/init.js` file (which will be run in load_ipython_extension?

By doing so, init() function in kernel side can be simplified or even removed, so that the notebook user (Py/R/Scala) user won't need to run the `init()` function in kernel.

For this commit, users don't need to run `declarativewidgets.init()` any longer in Python.